### PR TITLE
Change `DataStructures` to `OrderedCollections`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -5,13 +5,13 @@ version = "1.0.0-dev"
 
 [deps]
 Bibliography = "f1be7e48-bf82-45af-a471-ae754a193061"
-DataStructures = "864edb3b-99cc-5e75-8d2d-829cb0a9cfe8"
 Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
 Markdown = "d6f4376e-aef5-505a-96c1-9c027394607a"
+OrderedCollections = "bac558e1-5e72-5ebc-8fee-abe8a469f55d"
 Unicode = "4ec0a83e-493e-50e2-b9ac-8f72acf5a8f5"
 
 [compat]
 Bibliography = "^0.2"
-DataStructures = "0.18"
 Documenter = "0.27"
+OrderedCollections = "1"
 julia = "^1.6"

--- a/src/DocumenterCitations.jl
+++ b/src/DocumenterCitations.jl
@@ -12,7 +12,7 @@ using Documenter.Writers.HTMLWriter
 using Markdown
 using Bibliography
 using Bibliography: xyear, xlink, xtitle
-using DataStructures: OrderedDict, OrderedSet
+using OrderedCollections: OrderedDict, OrderedSet
 using Unicode
 
 export CitationBibliography


### PR DESCRIPTION
This patch changes the indirect dependency on `OrderedCollections` ( `DataStructures` -> `OrderedCollections`) to a direct dependency on `OrderedCollections`.