### PR TITLE
Emit a warning when using the default style

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -9,8 +9,8 @@ AUTHORS = join(PROJECT_TOML["authors"], ", ") * " and contributors"
 GITHUB = "https://github.com/JuliaDocs/DocumenterCitations.jl"
 
 bib = CitationBibliography(
-    joinpath(@__DIR__, "src", "refs.bib"),
-    # style=:numeric  # default
+    joinpath(@__DIR__, "src", "refs.bib");
+    style=:numeric  # default
 )
 
 println("Starting makedocs")

--- a/src/DocumenterCitations.jl
+++ b/src/DocumenterCitations.jl
@@ -70,10 +70,16 @@ struct CitationBibliography <: Documenter.Plugin
     page_citations::Dict{String,Set{String}}
 end
 
-function CitationBibliography(bibfile::AbstractString=""; style=:numeric, cached=true)
+function CitationBibliography(bibfile::AbstractString=""; style=nothing, cached=true)
     # note: cached is undocumented (on purpose), see comment at
     # _CACHED_PAGE_CITATIONS. Should be removed when Documenter 0.28 is
     # released
+    if isnothing(style)
+        @warn "The 1.0 release of DocumenterCitations changed the default citation style from author-year to numeric. To restore the pre-1.0 default style, use `CitationBibliography(bibfile; style=:authoryear)`."
+        # The warning is only to transition users through the breaking change
+        # in 1.0. It can be removed in any future 1.1 release.
+        style = :numeric
+    end
     entries = import_bibtex(bibfile)
     if length(bibfile) > 0
         if !isfile(bibfile)

--- a/src/DocumenterCitations.jl
+++ b/src/DocumenterCitations.jl
@@ -75,8 +75,8 @@ function CitationBibliography(bibfile::AbstractString=""; style=nothing, cached=
     # _CACHED_PAGE_CITATIONS. Should be removed when Documenter 0.28 is
     # released
     if isnothing(style)
-        @warn "The 1.0 release of DocumenterCitations changed the default citation style from author-year to numeric. To restore the pre-1.0 default style, use `CitationBibliography(bibfile; style=:authoryear)`."
-        # The warning is only to transition users through the breaking change
+        @info "The 1.0 release of DocumenterCitations changed the default citation style from author-year to numeric. To restore the pre-1.0 default style, use `CitationBibliography(bibfile; style=:authoryear)`."
+        # The message is only to transition users through the breaking change
         # in 1.0. It can be removed in any future 1.1 release.
         style = :numeric
     end


### PR DESCRIPTION
This is a temporary warning to transition users through the 1.0 breaking change of the default style from author-year to numeric. It can be removed in later releases.