### PR TITLE
Show "+" in alpha style for 4+ names

### DIFF
--- a/src/formatting.jl
+++ b/src/formatting.jl
@@ -88,6 +88,9 @@ function alpha_label(entry)
             ],
             "",
         )
+        if length(entry.authors) > 3
+            letters *= "+"
+        end
         return letters * year
     end
 end

--- a/test/test_formatting.jl
+++ b/test/test_formatting.jl
@@ -33,8 +33,8 @@ end
 @testset "alpha_label" begin
     bib = CitationBibliography(joinpath(@__DIR__, "..", "docs", "src", "refs.bib"),)
     @test alpha_label(bib.entries["Tannor2007"]) == "Tan07"
-    @test alpha_label(bib.entries["FuerstNJP2014"]) == "FGP14"
+    @test alpha_label(bib.entries["FuerstNJP2014"]) == "FGP+14"
     @test alpha_label(bib.entries["ImamogluPRE2015"]) == "IW15"
-    @test alpha_label(bib.entries["SciPy"]) == "JOP01"
+    @test alpha_label(bib.entries["SciPy"]) == "JOP+01"
     @test alpha_label(bib.entries["MATLAB:2014"]) == "MAT14"
 end


### PR DESCRIPTION
We should not disregard the names of all authors after the first three. This is one approach to handle this, i.e. add a "+" after the third character, if there are more names left out.