### PR TITLE
Update test dependencies

### DIFF
--- a/test/Project.toml
+++ b/test/Project.toml
@@ -1,12 +1,9 @@
 [deps]
-Bibliography = "f1be7e48-bf82-45af-a471-ae754a193061"
 Coverage = "a2441757-f6aa-5fb2-8edb-039e3f45d037"
-Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
-DocumenterCitations = "daee34ce-89f3-4625-b898-19384cb65244"
 JuliaFormatter = "98e50ef6-434e-11e9-1051-2b60c6c9e899"
 LiveServer = "16fef848-5104-11e9-1b77-fb7a48bbb589"
 LocalCoverage = "5f6e1e16-694c-5876-87ef-16b5274f298e"
-Markdown = "d6f4376e-aef5-505a-96c1-9c027394607a"
+Logging = "56ddb016-857b-54e1-b83d-db4d58db5568"
 PrettyTables = "08abe8d2-0d0c-5749-adfa-8a2ac140af0d"
 Revise = "295af30f-e4ad-537b-8983-00126c2a3abe"
 SafeTestsets = "1bc83da4-3b8d-516f-aca4-4fe02f6d838f"

--- a/test/test_makedocs.jl
+++ b/test/test_makedocs.jl
@@ -1,5 +1,5 @@
 using DocumenterCitations
-using Documenter
+using DocumenterCitations.Documenter
 using Logging
 using Test
 

--- a/test/test_parse_citation_link.jl
+++ b/test/test_parse_citation_link.jl
@@ -1,6 +1,6 @@
 using Test
 using DocumenterCitations: CitationLink
-using Markdown
+using DocumenterCitations.Markdown
 using Logging
 
 


### PR DESCRIPTION
`Logging` was missing.
`Bibliography`, `Documenter`, and `Markdown` are already contained in `Project.toml`, and thus a regular dependency and not a test dependency.
`DocumenterCitations`, i.e. the package itself, needs not to be included, as it gets added by `Pkg` implicitly (see here: https://pkgdocs.julialang.org/v1/creating-packages/#test/Project.toml-file-test-specific-dependencies).