### PR TITLE
Do not print non-existing years

### DIFF
--- a/src/formatting.jl
+++ b/src/formatting.jl
@@ -258,7 +258,7 @@ function format_published_in(entry; include_date=true)
         parts = [get(entry.fields, "note", ""),]
         str *= join(filter!(!isempty, parts), ", ")
     end
-    if include_date
+    if include_date && !isempty(entry.date.year)
         str *= " ($(entry.date.year))"
     end
     return str


### PR DESCRIPTION
If some bib entry does not contain a year (e.g. some website included as a `@Misc`), currently DocumenterCitations prints " ()" after the entry. This PR removes that.