### PR TITLE
Add support for `note` and `eprint` fields

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -7,17 +7,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-* Do not try include a year when rendering a reference if the underlying BibTeX entry has no `year` field.
-* Avoid duplicate labels in `:alpha` style. This is implemented via the new stateful `AlphaStyle()`, but is handled automatically.
+* Avoid duplicate labels in `:alpha` style. This is implemented via the new stateful `AlphaStyle()`, but is handled automatically with (`style=:alpha`).
 * With the alphabetic style (`:alpha`/`AlphaStyle`), include up to 4 names in the label, not 3 (but 5 or more names results in 3 names and "+"). Also, include the first letter of a "particle" in the label, e.g. "vWB08" for a first author "von Winckel". Both of these are consistent with LaTeX's behavior.
+* Handle missing author/year, especially for `:authoryar` and `:alpha` styles. You end up with `:alpha` labels like `Anon04` (missing authors) or `CW??` (missing year), and `:authoryear` citations like "(Anonymous, 2004)" and "(Corcovilos and Weiss, undated)".
+* Consistent punctuation in the rendered bibliography, including for cases of missing fields.
 
 ### Added
 
 * New `style=AlphaStyle()` that generates unique citation labels. This can mostly be considered internal, as `style=:alpha` is automatically upgraded to `style=AlphaStyle()`.
+* Support for `eprint` field. It is recommended to add the arXiv ID in the `eprint` field for any article whose DOI is behind a paywall.
+* Support for `note` field.
+
+### Changed
+
+* In the rendered bibliography, the BibTeX "URL" field is now linked via the title, while the "DOI" is linked via the journal information. This allows to have a DOI and URL at the same time, or a URL for an `@unpublished`/`@misc` citation. If there is a URL but no title, the URL is used as the title.
 
 ### Internal Changes
 
-* Added an internal function `init_bibliography!` that is called at the beginning of the `ExpandBibliography` pipeline step. This function is intended to initialized internal state either of the `style` object or the `CitationBibliography` plugin object before rendering any `@bibliography` blocks. This is used to generate unique citation labels for the new `AlphaStyle()`. For the other builtin styles, it is a no-op. Generally, `init_bibliography!` can help with implementing custom "stateful" styles.
+* Added an internal function `init_bibliography!` that is called at the beginning of the `ExpandBibliography` pipeline step. This function is intended to initialize internal state either of the `style` object or the `CitationBibliography` plugin object before rendering any `@bibliography` blocks. This is used to generate unique citation labels for the new `AlphaStyle()`. For the other builtin styles, it is a no-op. Generally, `init_bibliography!` can help with implementing custom "stateful" styles.
 
 
 ## [Version v1.0.0][1.0.0] - 2023-07-12

--- a/docs/latex/numeric.tex
+++ b/docs/latex/numeric.tex
@@ -37,6 +37,7 @@ kamsmath,amssymb,notitlepage,letterpaper]{revtex4-2}
   \item \verb|\citep*[Eq.~(1)]{GoerzQ2022}| renders as ``\citep*[Eq.~(1)]{GoerzQ2022}''.
   \item \verb|\citet{WinckelIP2008}| renders as ``\citet{WinckelIP2008}''.
   \item \verb|\Citet{WinckelIP2008}| renders as ``\Citet{WinckelIP2008}''.
+  \item \cite{GoerzPhd2015} and \cite{Luc-KoenigEPJD2004}
 \end{itemize}
 
 Further commands that we do not support in markdown:

--- a/docs/src/gallery.md
+++ b/docs/src/gallery.md
@@ -93,7 +93,7 @@ GraceJMO2007
 GraceJPB2007
 ```
 
-This works because the `DocumenterCitations` automatically upgrades `style=:alpha` to the internal
+This works because the `DocumenterCitations` plugin automatically upgrades `style=:alpha` to the internal
 
 ```@docs
 DocumenterCitations.AlphaStyle

--- a/docs/src/refs.bib
+++ b/docs/src/refs.bib
@@ -165,6 +165,8 @@
     Doi = {10.1088/0953-4075/44/15/154011},
     Pages = {154011},
     Volume = {44},
+    eprint = {1103.6050},
+    note = {Special issue on quantum control theory for coherence and information dynamics},
 }
 
 
@@ -176,6 +178,7 @@
     Doi = {10.1103/PhysRevA.86.043424},
     Pages = {043424},
     Volume = {86},
+    eprint = {1208.4331},
 }
 
 @article{GoerzNJP2014,
@@ -186,6 +189,7 @@
     Doi = {10.1088/1367-2630/16/5/055012},
     Pages = {055012},
     Volume = {16},
+    note = {Special issue on coherent control of complex quantum systems},
 }
 
 @article{GoerzPRA2014,
@@ -196,6 +200,8 @@
     Doi = {10.1103/PhysRevA.90.032329},
     Pages = {032329},
     Volume = {90},
+    eprint = {1401.1858},
+    note = {Editor's suggestion},
 }
 
 @article{JaegerPRA2014,
@@ -206,6 +212,7 @@
     Doi = {10.1103/PhysRevA.90.033628},
     Pages = {033628},
     Volume = {90},
+    eprint = {1409.2976},
 }
 
 @article{FuerstNJP2014,
@@ -216,13 +223,14 @@
     Doi = {10.1088/1367-2630/16/7/075007},
     Pages = {075007},
     Volume = {16},
+    note = {Special issue on coherent control of complex quantum systems},
 }
 
 @phdthesis{GoerzPhd2015,
     Author = {Goerz, Michael},
     Title = {Optimizing Robust Quantum Gates in Open Quantum Systems},
     School = {Universität Kassel},
-    url = {https://michaelgoerz.net/#PhD-Thesis},
+    url = {https://kobra.uni-kassel.de/handle/123456789/2015052748381},
     Year = {2015},
 }
 
@@ -234,6 +242,7 @@
     Doi = {10.1103/PhysRevA.91.062307},
     Pages = {062307},
     Volume = {91},
+    eprint = {1412.7350},
 }
 
 @article{WattsPRA2015,
@@ -244,6 +253,7 @@
     Doi = {10.1103/PhysRevA.91.062306},
     Pages = {062306},
     Volume = {91},
+    eprint = {1412.7347},
 }
 
 @article{GoerzEPJQT2015,
@@ -274,6 +284,7 @@
     Doi = {10.1103/PhysRevA.97.062339},
     Pages = {062339},
     Volume = {97},
+    eprint = {1804.08783},
 }
 
 @article{GoerzQST2018,
@@ -284,6 +295,7 @@
     Doi = {10.1088/2058-9565/aace16},
     Pages = {045005},
     Volume = {3},
+    eprint = {1801.04382},
 }
 
 @article{GoerzSPP2019,
@@ -302,6 +314,7 @@
     Doi = {10.1117/12.2587002},
     Booktitle = {Proc. SPIE 11700, Optical and Quantum Sensing and Precision Metrology},
     Year = {2021},
+    url = {https://michaelgoerz.net/research/GoerzSPIEO2021.pdf},
 }
 
 @article{GoerzQ2022,
@@ -312,8 +325,6 @@
     Doi = {10.22331/q-2022-12-07-871},
     Pages = {871},
     Volume = {6},
-    eprint = {2205.15044},
-    Archiveprefix = {arXiv},
 }
 
 @article{RaithelQST2022,
@@ -334,6 +345,7 @@
     Doi = {10.1103/physrevapplied.17.064050},
     Pages = {064050},
     Volume = {17},
+    eprint = {2201.01744},
 }
 
 @article{GoerzA2023,
@@ -344,6 +356,8 @@
     Doi = {10.3390/atoms11020036},
     Pages = {36},
     Volume = {11},
+    eprint = {2212.12602},
+    note = {Special issue on Advances in and Prospects for Matter Wave Interferometry},
 }
 
 @book{Tannor2007,
@@ -352,6 +366,7 @@
     publisher = {University Science Books},
     title = {Introduction to Quantum Mechanics: A Time-Dependent Perspective},
     year = {2007},
+    Url = {https://uscibooks.aip.org/books/introduction-to-quantum-mechanics-a-time-dependent-perspective/},
 }
 
 @incollection{TannorBookChapter1991,
@@ -361,6 +376,7 @@
     pages = {333--345},
     publisher = {Springer},
     title = {Design of Femtosecond Pulse Sequences to Control Photochemical Products},
+    doi = {0.1007/978-94-011-2642-7_23},
     year = {1991},
 }
 
@@ -382,6 +398,7 @@
     Doi = {10.1103/PhysRevA.95.062325},
     Pages = {062325},
     Volume = {95},
+    eprint= {1705.06150},
 }
 
 @article{WinckelIP2008,
@@ -403,6 +420,7 @@
     Pages = {022714},
     Volume = {91},
     Number = {2},
+    arxiv = {1408.5798},
 }
 
 @unpublished{Evans1983,
@@ -439,6 +457,7 @@
     Doi = {10.1103/PhysRevA.79.063411},
     Pages = {063411},
     Volume = {79},
+    eprint = {0906.1051},
 }
 
 
@@ -450,6 +469,7 @@
     Doi = {10.1080/09500340701639615},
     Pages = {2339},
     Volume = {54},
+    eprint = {0712.2935},
 }
 
 
@@ -461,6 +481,7 @@
     Doi = {10.1088/0953-4075/40/9/s06},
     Pages = {S103},
     Volume = {40},
+    eprint = {quant-ph/0702147},
 }
 
 
@@ -472,6 +493,7 @@
     Doi = {10.1103/PhysRevA.80.053625},
     Pages = {053625},
     Volume = {80},
+    eprint = {0908.1634},
 }
 
 
@@ -483,5 +505,49 @@
     Doi = {10.1103/PhysRevA.79.021603},
     Pages = {021603},
     Volume = {79},
+    eprint = {0806.3877},
 }
 
+
+@article{Luc-KoenigEPJD2004,
+    Author = {Luc-Koenig, E. and Vatasescu, M. and Masnou-Seeuws, F.},
+    Title = {Optimizing the photoassociation of cold atoms by use of chirped laser pulses},
+    Journal = epjd,
+    Year = {2004},
+    Doi = {10.1140/epjd/e2004-00161-8},
+    Pages = {239},
+    Volume = {31},
+    Number = {2},
+    eprint = {physics/0407112},
+    primaryClass = {physics.atm-clus},
+    Archiveprefix = {arXiv},
+}
+
+@article{Wilhelm2003.10132,
+    Author = {Wilhelm, Frank K. and Kirchhoff, Susanna and Machnes, Shai and Wittler, Nicolas and Sugny, Dominique},
+    Title = {An introduction into optimal control for quantum technologies},
+    Journal = {arXiv:2003.10132},
+    Year = {2020},
+    Doi = {10.48550/ARXIV.2003.10132},
+}
+
+@misc{QCRoadmap,
+    editor = {Todd Heinrichs},
+    title = {Quantum Computation Roadmap},
+    url = {http://qist.lanl.gov},
+    note = {Version 2.0; April 2, 2004},
+    Year = {2004},
+}
+
+@unpublished{TedRyd,
+  author    =      {Corcovilos, T. and Weiss, D. S.},
+  title     =      {Rydberg Calculations},
+  note = {Private communication}
+}
+
+
+@misc{jax,
+  author = {James Bradbury and Roy Frostig and Peter Hawkins and Matthew James Johnson and Chris Leary and Dougal Maclaurin and George Necula and Adam Paszke and Jake Vander{P}las and Skye Wanderman-{M}ilne and Qiao Zhang},
+  title = {JAX: composable transformations of Python+NumPy programs},
+  url = {https://github.com/google/jax},
+}

--- a/docs/src/syntax.md
+++ b/docs/src/syntax.md
@@ -183,10 +183,22 @@ In general, the citation style determines the order of the references, see the [
 
 The [`refs.bib`](./refs.bib) file is in the standard [BibTeX format](https://www.bibtex.com/g/bibtex-format/). It must be parsable by [BibParser.jl](https://github.com/Humans-of-Julia/BibParser.jl).
 
-The use of `@string` macros for abbreviated journal names is encouraged, with the caveat of [#31](https://github.com/Humans-of-Julia/BibParser.jl/issues/31) and [#32](https://github.com/Humans-of-Julia/BibParser.jl/issues/32) in the [BibParser.jl issues](https://github.com/Humans-of-Julia/BibParser.jl/issues).
+You will find that you get the best results by maintaining a `.bib` files by hand, specifically for a given project using `DocumenterCitations`. A `.bib` file that works well with LaTeX may or may not work well with `DocumenterCitations`: remember that in LaTeX, the strings inside any BibTeX fields are rendered through the TeX engine. At least in principle, they may contain arbitrary macros.
 
-Also, even though `DocumenterCitations` has limited support for [escaped symbols](http://www.bibtex.org/SpecialSymbols/), the full use of unicode is both supported and strongly encouraged.
+In contrast, for `DocumenterCitations`, the BibTeX fields are minimally processed to convert some common LaTeX constructs to plain text, but beyond that, they are used "as-is". In future versions, the handling of LaTeX macros may improve, but it is best not to rely on it, and instead edit the `.bib` file so that it gives good results with `DocumenterCitations` (see the tips below).
 
-All entries should have a `Doi` field, or a `Url` field if no DOI is available.
+While we try to be reasonably compatible, "Any `.bib` file will render the bibliography you expect" is not a design goal, but "It is possible to write a `.bib` file so that you get exactly the bibliography you want" is.
 
-You may be interested in using the [`getbibtex` script](https://github.com/goerz/getbibtex) to generate consistent `.bib` files.
+Some tips to keep in mind when editing a `.bib` file to be used with `DocumenterCitations`:
+
+* Use unicode instead of [escaped symbols](http://www.bibtex.org/SpecialSymbols/).
+* You do not need to use [braces to protect capitalization](https://texfaq.org/FAQ-capbibtex). `DocumenterCitations` is not always able to remove such braces. But, unlike `bibtex`, `DocumenterCitation` will preserve the capitalization of titles.
+* Use a consistent scheme for citation keys. Shorter keys are better.
+* All entries should have a `Doi` field, or a `Url` field if no DOI is available.
+* If the published paper (`Doi` link) is not open-access, but a version of the paper is available on the [arXiv](https://arxiv.org), include the arXiv ID as `eprint` in the BibTeX entry. In the rendered bibliography, there will be a link to `https://arxiv.org/abs/<ID>`.
+* It is not necessary to define `Archiveprefix` in the `.bib` file. A missing `Archiveprefix` is assumed to be `arXiv`.
+* For documents that are available only as an arXiv eprint, the best result is obtained with a BibTeX entry using the `@article` class, with, e.g., `arXiv:2003.10132` in the `Journal` field, and, e.g., `10.48550/ARXIV.2003.10132` in the `Doi` field (but no `eprint` field).
+* Use `@string` macros for abbreviated journal names, with the caveat of [#31](https://github.com/Humans-of-Julia/BibParser.jl/issues/31) and [#32](https://github.com/Humans-of-Julia/BibParser.jl/issues/32) in the [BibParser.jl issues](https://github.com/Humans-of-Julia/BibParser.jl/issues).
+
+
+You may be interested in using (or forking) the [`getbibtex` script](https://github.com/goerz/getbibtex) to generate consistent `.bib` files.

--- a/src/citations.jl
+++ b/src/citations.jl
@@ -288,12 +288,18 @@ function format_citation(
     names =
         format_names(entry; names=:lastonly, and=true, et_al, et_al_text="*et al.*") |>
         tex2unicode
+    if isempty(names)
+        names = "Anonymous"
+    end
 
     if cite_cmd == :citep
         cite_cmd = :cite
     end
 
     year = entry.date.year |> tex2unicode
+    if isempty(year)
+        year = "undated"
+    end
     if !isnothing(note)
         year *= ", $note"
     end

--- a/test/Project.toml
+++ b/test/Project.toml
@@ -12,7 +12,9 @@ PrettyTables = "08abe8d2-0d0c-5749-adfa-8a2ac140af0d"
 Revise = "295af30f-e4ad-537b-8983-00126c2a3abe"
 SafeTestsets = "1bc83da4-3b8d-516f-aca4-4fe02f6d838f"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+TestingUtilities = "40452611-1178-4e48-bdfc-3af4bebad9c9"
 
 [compat]
 Coverage = "^1.4"
-LocalCoverage = "0.4"
+LocalCoverage = "0.6"
+TestingUtilities = "1.7"

--- a/test/test_formatting.jl
+++ b/test/test_formatting.jl
@@ -1,18 +1,26 @@
 using Test
+using TestingUtilities: @Test  # much better at comparing long strings
 using Logging
+using OrderedCollections: OrderedDict
 using DocumenterCitations
-import DocumenterCitations: tex2unicode, two_digit_year, alpha_label
+import DocumenterCitations:
+    tex2unicode,
+    two_digit_year,
+    alpha_label,
+    format_citation,
+    format_bibliography_reference,
+    italicize_md_et_al
 
 @testset "text2unicode" begin
-    @test tex2unicode("-- ---") == "– —"
-    @test tex2unicode(
+    @Test tex2unicode("-- ---") == "– —"
+    @Test tex2unicode(
         raw"\`{o}\'{o}\^{o}\~{o}\={o}\u{o}\.{o}\\\"{o}\r{a}\H{o}\v{s}\d{u}\c{c}\k{a}\b{b}\~{a}"
     ) == "òóôõōŏȯöåőšụçąḇã"
-    @test tex2unicode(raw"\i{}\o{}\O{}\l{}\L{}\i\o\O\l\L") == "ıøØłŁıøØłŁ"
-    @test tex2unicode(raw"\t{oo}{testText}\t{az}") == "o͡otestTexta͡z"
-    @test tex2unicode(raw"{\o}verline") == "øverline"
-    @test tex2unicode(raw"\t{oo}\\\"{\i}{abcdefg}") == "o͡oïabcdefg"
-    @test tex2unicode(raw"\overline") == "\\overline"
+    @Test tex2unicode(raw"\i{}\o{}\O{}\l{}\L{}\i\o\O\l\L") == "ıøØłŁıøØłŁ"
+    @Test tex2unicode(raw"\t{oo}{testText}\t{az}") == "o͡otestTexta͡z"
+    @Test tex2unicode(raw"{\o}verline") == "øverline"
+    @Test tex2unicode(raw"\t{oo}\\\"{\i}{abcdefg}") == "o͡oïabcdefg"
+    @Test tex2unicode(raw"\overline") == "\\overline"
 end
 
 @testset "two_digit_year" begin
@@ -40,4 +48,66 @@ end
     @test alpha_label(bib.entries["LapertPRA09"]) == "LTTS09"
     @test alpha_label(bib.entries["GrondPRA2009b"]) == "GvWSH09"
     @test alpha_label(bib.entries["WinckelIP2008"]) == "vWB08"
+    @test alpha_label(bib.entries["QCRoadmap"]) == "Anon04"
+    @test alpha_label(bib.entries["TedRyd"]) == "CW??"
+    @test alpha_label(bib.entries["jax"]) == "BFH+??"
+end
+
+
+@testset "format_citation(:authoryear)" begin
+    bib = CitationBibliography(joinpath(@__DIR__, "..", "docs", "src", "refs.bib"),)
+    _c = OrderedDict{String,Int64}()
+    ctext(key; kwargs...) =
+        format_citation(Val(:authoryear), bib.entries[key], _c; kwargs...)
+    # Pathological cases only
+    @Test ctext("QCRoadmap") == "(Anonymous, 2004)"
+    @Test ctext("TedRyd") == "(Corcovilos and Weiss, undated)"
+end
+
+
+@testset "format_bibliography_reference(:numeric)" begin
+    bib = CitationBibliography(joinpath(@__DIR__, "..", "docs", "src", "refs.bib"),)
+    html(key) = format_bibliography_reference(Val(:numeric), bib.entries[key])
+    @Test html("GoerzJPB2011") ==
+          "M. H. Goerz, T. Calarco and C. P. Koch. <i>The quantum speed limit of optimal controlled phasegates for trapped neutral atoms</i>. <a href='https://doi.org/10.1088/0953-4075/44/15/154011'>J. Phys. B <b>44</b>, 154011 (2011)</a>, <a href='https://arxiv.org/abs/1103.6050'>arXiv:1103.6050</a>. Special issue on quantum control theory for coherence and information dynamics."
+    @Test html("Luc-KoenigEPJD2004") ==
+          "E. Luc-Koenig, M. Vatasescu and F. Masnou-Seeuws. <i>Optimizing the photoassociation of cold atoms by use of chirped laser pulses</i>. <a href='https://doi.org/10.1140/epjd/e2004-00161-8'>Eur. Phys. J. D <b>31</b>, 239 (2004)</a>, <a href='https://arxiv.org/abs/physics/0407112'>arXiv:physics/0407112 [physics.atm-clus]</a>."
+    @Test html("GoerzNPJQI2017") ==
+          "M. H. Goerz, F. Motzoi, K. B. Whaley and C. P. Koch. <i>Charting the circuit QED design landscape using optimal control theory</i>, <a href='https://doi.org/10.1038/s41534-017-0036-0'>npj Quantum Inf <b>3</b>, 37 (2017)</a>."
+    @Test html("Wilhelm2003.10132") ==
+          "F. K. Wilhelm, S. Kirchhoff, S. Machnes, N. Wittler and D. Sugny. <i>An introduction into optimal control for quantum technologies</i>, <a href='https://doi.org/10.48550/ARXIV.2003.10132'>arXiv:2003.10132 (2020)</a>."
+    @Test html("Evans1983") ==
+          "L. C. Evans. <a href='https://math.berkeley.edu/~evans/control.course.pdf'><i>An Introduction to Mathematical Optimal Control Theory</i></a> (1983). Lecture Notes, University of California, Berkeley."
+    @Test html("Giles2008b") ==
+          "M. B. Giles. <a href='https://people.maths.ox.ac.uk/gilesm/files/NA-08-01.pdf'><i>An extended collection of matrix derivative results for forward and reverse mode automatic differentiation</i></a>. Technical Report NA-08-01, Oxford University Computing Laboratory (2008)."
+    @Test html("QCRoadmap") ==
+          "<a href='http://qist.lanl.gov'><i>Quantum Computation Roadmap</i></a> (2004). Version 2.0; April 2, 2004."
+    @Test html("TedRyd") ==
+          "T. Corcovilos and D. S. Weiss. <i>Rydberg Calculations</i>. Private communication."
+    @Test html("jax") ==
+          "J. Bradbury, R. Frostig, P. Hawkins, M. J. Johnson, C. Leary, D. Maclaurin, G. Necula, A. Paszke, J. VanderPlas, S. Wanderman-Milne and Q. Zhang. <a href='https://github.com/google/jax'><i>JAX: composable transformations of Python+NumPy programs</i></a>."
+end
+
+
+@testset "format_bibliography_reference(:authoryear)" begin
+    bib = CitationBibliography(joinpath(@__DIR__, "..", "docs", "src", "refs.bib"),)
+    html(key) = format_bibliography_reference(Val(:authoryear), bib.entries[key])
+    @Test html("GoerzJPB2011") ==
+          "Goerz, M. H.; Calarco, T. and Koch, C. P. (2011). <i>The quantum speed limit of optimal controlled phasegates for trapped neutral atoms</i>. <a href='https://doi.org/10.1088/0953-4075/44/15/154011'>J. Phys. B <b>44</b>, 154011</a>, <a href='https://arxiv.org/abs/1103.6050'>arXiv:1103.6050</a>. Special issue on quantum control theory for coherence and information dynamics."
+    @Test html("Luc-KoenigEPJD2004") ==
+          "Luc-Koenig, E.; Vatasescu, M. and Masnou-Seeuws, F. (2004). <i>Optimizing the photoassociation of cold atoms by use of chirped laser pulses</i>. <a href='https://doi.org/10.1140/epjd/e2004-00161-8'>Eur. Phys. J. D <b>31</b>, 239</a>, <a href='https://arxiv.org/abs/physics/0407112'>arXiv:physics/0407112 [physics.atm-clus]</a>."
+    @Test html("GoerzNPJQI2017") ==
+          "Goerz, M. H.; Motzoi, F.; Whaley, K. B. and Koch, C. P. (2017). <i>Charting the circuit QED design landscape using optimal control theory</i>, <a href='https://doi.org/10.1038/s41534-017-0036-0'>npj Quantum Inf <b>3</b>, 37</a>."
+    @Test html("Wilhelm2003.10132") ==
+          "Wilhelm, F. K.; Kirchhoff, S.; Machnes, S.; Wittler, N. and Sugny, D. (2020). <i>An introduction into optimal control for quantum technologies</i>, <a href='https://doi.org/10.48550/ARXIV.2003.10132'>arXiv:2003.10132</a>."
+    @Test html("Evans1983") ==
+          "Evans, L. C. (1983). <a href='https://math.berkeley.edu/~evans/control.course.pdf'><i>An Introduction to Mathematical Optimal Control Theory</i></a>. Lecture Notes, University of California, Berkeley."
+    @Test html("Giles2008b") ==
+          "Giles, M. B. (2008). <a href='https://people.maths.ox.ac.uk/gilesm/files/NA-08-01.pdf'><i>An extended collection of matrix derivative results for forward and reverse mode automatic differentiation</i></a>. Technical Report NA-08-01, Oxford University Computing Laboratory."
+    @Test html("QCRoadmap") ==
+          "— (2004). <a href='http://qist.lanl.gov'><i>Quantum Computation Roadmap</i></a>. Version 2.0; April 2, 2004."
+    @Test html("TedRyd") ==
+          "Corcovilos, T. and Weiss, D. S. <i>Rydberg Calculations</i>. Private communication."
+    @Test html("jax") ==
+          "Bradbury, J.; Frostig, R.; Hawkins, P.; Johnson, M. J.; Leary, C.; Maclaurin, D.; Necula, G.; Paszke, A.; VanderPlas, J.; Wanderman-Milne, S. and Zhang, Q. <a href='https://github.com/google/jax'><i>JAX: composable transformations of Python+NumPy programs</i></a>."
 end


### PR DESCRIPTION
Closes #20

There is also a workaround for https://github.com/Humans-of-Julia/BibInternal.jl/issues/22. If @Azzaare can merge https://github.com/Humans-of-Julia/BibInternal.jl/issues/23 before we merge this, I can remove the monkeypatched `Bibliography.BibInternal.make_bibtex_entry`.

I've also rewritten the "Syntax for the .bib file" section in the documentation a bit to include some of the discussion in #15, with some tips on how to write a "good" `.bib` file.

Currently, this builds on top of PR #31. Once that is merged, I will rebase.