### PR TITLE
Collect citations from docstrings

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,7 +59,6 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           DOCUMENTER_KEY: ${{ secrets.DOCUMENTER_KEY }}
-          JULIA_DEBUG: Documenter,DocumenterCitations
       - uses: actions/upload-artifact@v3
         with:
           name: documenter-citations-docs

--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
+## [Unreleased][]
+
+### Fixed
+
+* Collect citations that only occur in docstrings [[#39][], [#40][]]
+
+
 ## [Version 1.2.0][1.2.0] - 2023-09-16
 
 ### Version changes
@@ -70,6 +77,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [1.2.0]: https://github.com/JuliaDocs/DocumenterCitations.jl/compare/v1.1.0...v1.2.0
 [1.1.0]: https://github.com/JuliaDocs/DocumenterCitations.jl/compare/v1.0.0...v1.1.0
 [1.0.0]: https://github.com/JuliaDocs/DocumenterCitations.jl/compare/v0.2.12...v1.0.0
+[#40]: https://github.com/JuliaDocs/DocumenterCitations.jl/pull/40
+[#39]: https://github.com/JuliaDocs/DocumenterCitations.jl/issues/39
 [#36]: https://github.com/JuliaDocs/DocumenterCitations.jl/pull/36
 [#35]: https://github.com/JuliaDocs/DocumenterCitations.jl/issues/35
 [#32]: https://github.com/JuliaDocs/DocumenterCitations.jl/pull/32

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "DocumenterCitations"
 uuid = "daee34ce-89f3-4625-b898-19384cb65244"
 authors = ["Michael Goerz <mail@michaelgoerz.net>"]
-version = "1.2.0"
+version = "1.2.1-dev"
 
 [deps]
 AbstractTrees = "1520ce14-60c1-5f80-bbc7-55ef81b5835c"

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -21,6 +21,7 @@ include("custom_styles/keylabels.jl")
 makedocs(
     authors=AUTHORS,
     linkcheck=true,
+    warnonly=[:linkcheck,],
     sitename="DocumenterCitations.jl",
     format=Documenter.HTML(
         prettyurls=true,

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -26,6 +26,11 @@ using DocumenterCitations
         include("test_alphastyle.jl")
     end
 
+    print("\n* collect from docstrings (test_collect_from_docstrings.jl):")
+    @time @safetestset "collect_from_docstrings" begin
+        include("test_collect_from_docstrings.jl")
+    end
+
     print("\n* content_bock (test_content_block.jl):")
     @time @safetestset "content_block" begin
         include("test_content_block.jl")
@@ -44,6 +49,11 @@ using DocumenterCitations
     print("\n* integration test (test_integration.jl):")
     @time @safetestset "integration" begin
         include("test_integration.jl")
+    end
+
+    print("\n* test undefined citations (test_undefined_citations.jl):")
+    @time @safetestset "undefined_citations" begin
+        include("test_undefined_citations.jl")
     end
 
     print("\n")

--- a/test/test_collect_from_docstrings.jl
+++ b/test/test_collect_from_docstrings.jl
@@ -1,0 +1,45 @@
+using DocumenterCitations
+using Test
+
+include("run_makedocs.jl")
+
+
+@testset "Collect from docstrings" begin
+
+    # https://github.com/JuliaDocs/DocumenterCitations.jl/issues/39
+
+    bib = CitationBibliography(
+        joinpath(@__DIR__, "..", "docs", "src", "refs.bib"),
+        style=:numeric
+    )
+    run_makedocs(
+        splitext(@__FILE__)[1];
+        sitename="Test",
+        plugins=[bib],
+        pages=["Home" => "index.md", "References" => "references.md",]
+    ) do dir, result, success, backtrace, output
+
+        if !success
+            println("")
+            @error "Failed makedocs:\n$output" dir
+        end
+        if result isa Exception
+            @error "Raised $(typeof(result))\n" result
+        end
+
+        @test success
+
+        index_outfile = joinpath(dir, "build", "index.html")
+        @test isfile(index_outfile)
+        html = read(index_outfile, String)
+        @test occursin("citing Ref. <a href=\"references/#GoerzQ2022\">[1]</a>", html)
+
+        ref_outfile = joinpath(dir, "build", "references", "index.html")
+        @test isfile(ref_outfile)
+        html = read(ref_outfile, String)
+        @test occursin("<dt>[1]</dt>", html)
+        @test occursin("<div id=\"GoerzQ2022\">", html)
+
+    end
+
+end

--- a/test/test_collect_from_docstrings/src/index.md
+++ b/test/test_collect_from_docstrings/src/index.md
@@ -1,0 +1,11 @@
+# Testing collection of citations from docstrings
+
+
+## Problem description
+
+
+Citations that only occurred in docstrings were not being collected.
+
+```@docs
+DocumenterCitations.Example
+```

--- a/test/test_collect_from_docstrings/src/references.md
+++ b/test/test_collect_from_docstrings/src/references.md
@@ -1,0 +1,4 @@
+## References
+
+```@bibliography
+```

--- a/test/test_undefined_citations.jl
+++ b/test/test_undefined_citations.jl
@@ -1,0 +1,52 @@
+using DocumenterCitations
+using Test
+
+include("run_makedocs.jl")
+
+
+@testset "undefined citations" begin
+
+    bib = CitationBibliography(
+        joinpath(@__DIR__, "..", "docs", "src", "refs.bib"),
+        style=:numeric
+    )
+
+    # non-strict
+    run_makedocs(
+        splitext(@__FILE__)[1];
+        sitename="Test",
+        warnonly=true,
+        plugins=[bib],
+        pages=["Home" => "index.md", "References" => "references.md",]
+    ) do dir, result, success, backtrace, output
+
+        @test success
+        @test occursin("Error: Citation not found in bibliography: NoExist2023", output)
+
+    end
+
+    # strict
+    run_makedocs(
+        splitext(@__FILE__)[1];
+        sitename="Test",
+        warnonly=false,
+        plugins=[bib],
+        pages=["Home" => "index.md", "References" => "references.md",]
+    ) do dir, result, success, backtrace, output
+
+        #if !success
+        #   println("")
+        #   @error "Failed makedocs:\n$output" dir
+        #end
+        #if result isa Exception
+        #   @error "Raised $(typeof(result))\n" result
+        #end
+
+        @test !success
+        @test occursin("Error: Citation not found in bibliography: NoExist2023", output)
+        @test result isa ErrorException
+        @test occursin(r"`makedocs` encountered errors [ [,]*:citations", result.msg)
+
+    end
+
+end

--- a/test/test_undefined_citations/src/index.md
+++ b/test/test_undefined_citations/src/index.md
@@ -1,0 +1,3 @@
+# Testing error for citing a non-existent keys
+
+We cite an existing key [GoerzQ2022](@cite) and a non-existing key [NoExist2023](@cite).

--- a/test/test_undefined_citations/src/references.md
+++ b/test/test_undefined_citations/src/references.md
@@ -1,0 +1,4 @@
+## References
+
+```@bibliography
+```


### PR DESCRIPTION
Properly recurse into docstrings when collecting citations.

This adds a test that having a reference that is only cited in a docstrings works as expected.

Also adds a test that the error generated when there is an actual missing reference still correctly percolates up to `makedocs`.

Closes #39