### PR TITLE
Fix incompatibility of `@bibliography` and `@contents`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 * Collect citations that only occur in docstrings [[#39][], [#40][]]
+* It is now possible to have a page that contains a `@bibliography` block listed in [`@contents`](https://documenter.juliadocs.org/stable/man/syntax/index.html#@contents-block) [[#16][], [#42][]].
 
 
 ## [Version 1.2.0][1.2.0] - 2023-09-16
@@ -77,6 +78,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [1.2.0]: https://github.com/JuliaDocs/DocumenterCitations.jl/compare/v1.1.0...v1.2.0
 [1.1.0]: https://github.com/JuliaDocs/DocumenterCitations.jl/compare/v1.0.0...v1.1.0
 [1.0.0]: https://github.com/JuliaDocs/DocumenterCitations.jl/compare/v0.2.12...v1.0.0
+[#42]: https://github.com/JuliaDocs/DocumenterCitations.jl/pull/42
 [#40]: https://github.com/JuliaDocs/DocumenterCitations.jl/pull/40
 [#39]: https://github.com/JuliaDocs/DocumenterCitations.jl/issues/39
 [#36]: https://github.com/JuliaDocs/DocumenterCitations.jl/pull/36
@@ -85,3 +87,4 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#31]: https://github.com/JuliaDocs/DocumenterCitations.jl/pull/31
 [#20]: https://github.com/JuliaDocs/DocumenterCitations.jl/issues/20
 [#19]: https://github.com/JuliaDocs/DocumenterCitations.jl/issues/19
+[#16]: https://github.com/JuliaDocs/DocumenterCitations.jl/issues/16

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -85,7 +85,6 @@ bib = CitationBibliography(
 makedocs(;
     authors=AUTHORS,
     sitename="DocumenterCitations.jl",
-    strict=true,
     format=Documenter.HTML(
         prettyurls=true,
         canonical="https://juliaquantumcontrol.github.io/DocumenterCitations.jl",

--- a/src/DocumenterCitations.jl
+++ b/src/DocumenterCitations.jl
@@ -22,9 +22,8 @@ export CitationBibliography
 bib = CitationBibliography(bibfile; style=:numeric)
 ```
 
-instantiates a plugin that must be passed as an (undocumented!) positional
-argument to
-[`Documenter.makedocs`](https://documenter.juliadocs.org/stable/lib/public/#Documenter.makedocs).
+instantiates a plugin object that must be passed as an element of the `plugins`
+keyword argument to [`Documenter.makedocs`](https://documenter.juliadocs.org/stable/lib/public/#Documenter.makedocs).
 
 # Arguments
 
@@ -43,6 +42,9 @@ should not be considered part of the stable API.
 * `citations`: ordered dict of citation key to citation number
 * `page_citations`: dict of page file name to set of citation keys cited on
   page.
+* `anchor_map`: an [`AnchorMap`](https://documenter.juliadocs.org/stable/lib/internals/anchors/#Documenter.AnchorMap)
+  object that keeps track of the link anchors for references in bibliography
+  blocks
 """
 struct CitationBibliography <: Documenter.Plugin
     # name of bib file
@@ -56,6 +58,9 @@ struct CitationBibliography <: Documenter.Plugin
     citations::OrderedDict{String,Int64}
     # page file name => set of citation keys (private)
     page_citations::Dict{String,Set{String}}
+    # AnchorMap object that stores the link anchors to all references in
+    # canonical bibliography blocks
+    anchor_map::Documenter.AnchorMap
 end
 
 function CitationBibliography(bibfile::AbstractString=""; style=nothing)
@@ -77,7 +82,15 @@ function CitationBibliography(bibfile::AbstractString=""; style=nothing)
     end
     citations = OrderedDict{String,Int64}()
     page_citations = Dict{String,Set{String}}()
-    return CitationBibliography(bibfile, style, entries, citations, page_citations)
+    anchor_map = Documenter.AnchorMap()
+    return CitationBibliography(
+        bibfile,
+        style,
+        entries,
+        citations,
+        page_citations,
+        anchor_map
+    )
 end
 
 

--- a/src/bibliography.jl
+++ b/src/bibliography.jl
@@ -439,7 +439,7 @@ function expand_bibliography(node::MarkdownAST.Node, meta, page, doc)
     if fields[:Canonical]
         html = """<div class="citation canonical"><$tag>"""
     end
-    headers = doc.internal.headers
+    anchors = bib.anchor_map
     entries = OrderedDict{String,Bibliography.Entry}(
         key => bib.entries[key] for key in keys_to_show
     )
@@ -454,7 +454,7 @@ function expand_bibliography(node::MarkdownAST.Node, meta, page, doc)
         @assert entry.id == key
         if fields[:Canonical]
             # Add anchor that citations can link to from anywhere in the docs.
-            if Documenter.anchor_exists(headers, key)
+            if Documenter.anchor_exists(anchors, key)
                 # Skip entries that already have a canonical bib entry
                 # elsewhere. This is expected behavior, not an error/warning,
                 # allowing to split the canonical bibliography in multiple
@@ -463,7 +463,7 @@ function expand_bibliography(node::MarkdownAST.Node, meta, page, doc)
                 continue
             else
                 @debug "Defining anchor for key=$(key)"
-                Documenter.anchor_add!(headers, entry, key, page.build)
+                Documenter.anchor_add!(anchors, entry, key, page.build)
             end
         else
             # For non-canonical bibliographies, no anchors are generated, and

--- a/src/citations.jl
+++ b/src/citations.jl
@@ -418,11 +418,11 @@ function expand_citation(node::MarkdownAST.Node, meta, page, doc)
     if haskey(bib.entries, key)
         entry = bib.entries[key]
         @assert entry.id == key
-        headers = doc.internal.headers
-        if Documenter.anchor_exists(headers, key)
-            if Documenter.anchor_isunique(headers, key)
+        anchors = bib.anchor_map
+        if Documenter.anchor_exists(anchors, key)
+            if Documenter.anchor_isunique(anchors, key)
                 # Replace the `@cite` url with a path to the referenced header.
-                anchor = Documenter.anchor(headers, key)
+                anchor = Documenter.anchor(anchors, key)
                 path   = relpath(anchor.file, dirname(page.build))
                 if isnothing(cit.link_text)
                     @assert length(node.children) == 1 &&

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -6,52 +6,52 @@ using DocumenterCitations
 # Note: comment outer @testset to stop after first @safetestset failure
 @time @testset verbose = true "DocumenterCitations" begin
 
-    print("\n* formatting (test_formatting.jl):")
+    println("\n* formatting (test_formatting.jl):")
     @time @safetestset "formatting" begin
         include("test_formatting.jl")
     end
 
-    print("\n* parse_bibliography_block (test_parse_bibliography_block.jl):")
+    println("\n* parse_bibliography_block (test_parse_bibliography_block.jl):")
     @time @safetestset "parse_bibliography_block" begin
         include("test_parse_bibliography_block.jl")
     end
 
-    print("\n* parse_citation_link (test_parse_citation_link.jl):")
+    println("\n* parse_citation_link (test_parse_citation_link.jl):")
     @time @safetestset "parse_citation_link" begin
         include("test_parse_citation_link.jl")
     end
 
-    print("\n* smart alpha style (test_alphastyle.jl):")
+    println("\n* smart alpha style (test_alphastyle.jl):")
     @time @safetestset "smart alpha style" begin
         include("test_alphastyle.jl")
     end
 
-    print("\n* collect from docstrings (test_collect_from_docstrings.jl):")
+    println("\n* collect from docstrings (test_collect_from_docstrings.jl):")
     @time @safetestset "collect_from_docstrings" begin
         include("test_collect_from_docstrings.jl")
     end
 
-    print("\n* content_bock (test_content_block.jl):")
+    println("\n* content_bock (test_content_block.jl):")
     @time @safetestset "content_block" begin
         include("test_content_block.jl")
     end
 
-    print("\n* md_ast (test_md_ast.jl):")
+    println("\n* md_ast (test_md_ast.jl):")
     @time @safetestset "md_ast" begin
         include("test_md_ast.jl")
     end
 
-    print("\n* keys_with_underscores (test_keys_with_underscores.jl):")
+    println("\n* keys_with_underscores (test_keys_with_underscores.jl):")
     @time @safetestset "keys_with_underscores" begin
         include("test_keys_with_underscores.jl")
     end
 
-    print("\n* integration test (test_integration.jl):")
+    println("\n* integration test (test_integration.jl):")
     @time @safetestset "integration" begin
         include("test_integration.jl")
     end
 
-    print("\n* test undefined citations (test_undefined_citations.jl):")
+    println("\n* test undefined citations (test_undefined_citations.jl):")
     @time @safetestset "undefined_citations" begin
         include("test_undefined_citations.jl")
     end

--- a/test/test_collect_from_docstrings.jl
+++ b/test/test_collect_from_docstrings.jl
@@ -16,16 +16,9 @@ include("run_makedocs.jl")
         splitext(@__FILE__)[1];
         sitename="Test",
         plugins=[bib],
-        pages=["Home" => "index.md", "References" => "references.md",]
+        pages=["Home" => "index.md", "References" => "references.md",],
+        check_success=true
     ) do dir, result, success, backtrace, output
-
-        if !success
-            println("")
-            @error "Failed makedocs:\n$output" dir
-        end
-        if result isa Exception
-            @error "Raised $(typeof(result))\n" result
-        end
 
         @test success
 

--- a/test/test_content_block.jl
+++ b/test/test_content_block.jl
@@ -22,13 +22,12 @@ include("run_makedocs.jl")
     ) do dir, result, success, backtrace, output
         #if !success
         #    println("")
-        #    @error "Failed makedocs:\n$output" dir  # XXX
+        #    @error "Failed makedocs:\n$output" dir
         #end
         #if result isa Exception
-        #    @error "Raised $(typeof(result))\n" result  # XXX
+        #    @error "Raised $(typeof(result))\n" result
         #end
-        @test result == ErrorException("type Entry has no field level")  # XXX
-        @test_broken success
+        @test success
     end
 
 end

--- a/test/test_content_block.jl
+++ b/test/test_content_block.jl
@@ -18,15 +18,9 @@ include("run_makedocs.jl")
         joinpath(@__DIR__, "test_content_block");
         sitename="Test",
         plugins=[bib],
-        pages=["Home" => "index.md", "References" => "references.md",]
+        pages=["Home" => "index.md", "References" => "references.md",],
+        check_success=true
     ) do dir, result, success, backtrace, output
-        #if !success
-        #    println("")
-        #    @error "Failed makedocs:\n$output" dir
-        #end
-        #if result isa Exception
-        #    @error "Raised $(typeof(result))\n" result
-        #end
         @test success
     end
 

--- a/test/test_integration.jl
+++ b/test/test_integration.jl
@@ -38,10 +38,9 @@ include(CUSTOM2)
             "CSS Styling"            => "styling.md",
             "Internals"              => "internals.md",
             "References"             => "references.md",
-        ]
+        ],
+        check_success=true
     ) do dir, result, success, backtrace, output
-
-        success || @error "Failed makedocs:\n$output" dir
 
         @test success
         @test occursin("Info: CollectCitations", output)

--- a/test/test_keys_with_underscores.jl
+++ b/test/test_keys_with_underscores.jl
@@ -5,7 +5,7 @@ using Test
 include("run_makedocs.jl")
 
 
-@testset "@Contents Block Test" begin
+@testset "keys with underscores" begin
 
     # https://github.com/JuliaDocs/DocumenterCitations.jl/issues/14
 
@@ -17,15 +17,9 @@ include("run_makedocs.jl")
         joinpath(@__DIR__, "test_keys_with_underscores");
         sitename="Test",
         plugins=[bib],
-        pages=["Home" => "index.md", "References" => "references.md",]
+        pages=["Home" => "index.md", "References" => "references.md",],
+        check_failure=true # XXX
     ) do dir, result, success, backtrace, output
-        #if !success
-        #    println("")
-        #    @error "Failed makedocs:\n$output" dir  # XXX
-        #end
-        #if result isa Exception
-        #    @error "Raised $(typeof(result))\n" result  # XXX
-        #end
         @test result isa ErrorException # XXX
         @test occursin("Invalid citation", result.msg)  # XXX
         @test_broken success

--- a/test/test_undefined_citations.jl
+++ b/test/test_undefined_citations.jl
@@ -17,7 +17,8 @@ include("run_makedocs.jl")
         sitename="Test",
         warnonly=true,
         plugins=[bib],
-        pages=["Home" => "index.md", "References" => "references.md",]
+        pages=["Home" => "index.md", "References" => "references.md",],
+        check_success=true
     ) do dir, result, success, backtrace, output
 
         @test success
@@ -31,16 +32,9 @@ include("run_makedocs.jl")
         sitename="Test",
         warnonly=false,
         plugins=[bib],
-        pages=["Home" => "index.md", "References" => "references.md",]
+        pages=["Home" => "index.md", "References" => "references.md",],
+        check_failure=true
     ) do dir, result, success, backtrace, output
-
-        #if !success
-        #   println("")
-        #   @error "Failed makedocs:\n$output" dir
-        #end
-        #if result isa Exception
-        #   @error "Raised $(typeof(result))\n" result
-        #end
 
         @test !success
         @test occursin("Error: Citation not found in bibliography: NoExist2023", output)


### PR DESCRIPTION
Use an independent `AnchorMap` to keep track of targets in the canonical `@bibliography` blocks.

Closes #16