### PR TITLE
Remove workarounds for bugs fixed in BibInternal 0.3.5

### DIFF
--- a/docs/src/syntax.md
+++ b/docs/src/syntax.md
@@ -198,7 +198,6 @@ Some tips to keep in mind when editing a `.bib` file to be used with `Documenter
 * You do not need to use [braces to protect capitalization](https://texfaq.org/FAQ-capbibtex). Unlike `bibtex`, `DocumenterCitation` will preserve the capitalization of titles. You should always put the title in the `.bib` file as it appears in the published paper.
 * Use a consistent scheme for citation keys. Shorter keys are better.
 * All entries should have a `Doi` field, or a `Url` field if no DOI is available.
-* You may have to work around some bugs in [BibParser.jl](https://github.com/Humans-of-Julia/BibParser.jl]). For example, the parser [does not properly recognize organization names as authors](https://github.com/Humans-of-Julia/BibParser.jl/issues/30). A [workaround](https://github.com/JuliaDocs/DocumenterCitations.jl/issues/44#issuecomment-1762167119) is to use non-breaking spaces in the name.
 * Use `@string` macros for abbreviated journal names, with the caveat of [#31](https://github.com/Humans-of-Julia/BibParser.jl/issues/31) and [#32](https://github.com/Humans-of-Julia/BibParser.jl/issues/32) in the [BibParser.jl issues](https://github.com/Humans-of-Julia/BibParser.jl/issues).
 
 

--- a/src/DocumenterCitations.jl
+++ b/src/DocumenterCitations.jl
@@ -173,24 +173,6 @@ end
 Base.show(io::IO, ::AlphaStyle) = print(io, "AlphaStyle()")
 
 
-# Work around https://github.com/Humans-of-Julia/BibInternal.jl/issues/22
-# This is a monkey-patch of the original routine. We give it preference with
-# the type annotation `::String` for the id.
-function Bibliography.BibInternal.make_bibtex_entry(id::String, fields; check=:error)
-    # "eprint" ∈ keys(fields) && (fields["_type"] = "eprint")  # bug #22
-    fields = Dict(lowercase(k) => v for (k, v) in fields) # lowercase tag names
-    errors = Bibliography.BibInternal.check_entry(fields, check, id)
-    if length(errors) > 0 && check ∈ [:error, :warn]
-        message =
-            "Entry $id is missing the " *
-            foldl(((x, y) -> x * ", " * y), errors) *
-            " field(s)."
-        check == :error ? (@error message) : (@warn message)
-    end
-    return Bibliography.BibInternal.Entry(id, fields)
-end
-
-
 include("md_ast.jl")
 include("citation_link.jl")
 include("collect_citations.jl")


### PR DESCRIPTION
The release of `BibInternal v0.3.5` solved issue https://github.com/Humans-of-Julia/BibInternal.jl/issues/22 related to preprints. Our monkey-patch of `BibInternal.make_bibtex_entry` to work around this is no longer necessary.

The release also solved issue https://github.com/Humans-of-Julia/BibInternal.jl/pull/21, so the description of the workaround in the documentation can be removed.

Note that `BibInternal` is only an implicit dependency (via `Bibliography.jl`). The lowest compat-bound for `Bibliography.jl`, that is, `v0.2.15`, is compatible with `BibInternal v0.3.5`. So that version should be installed automatically. Someone would have to go out of their way to pin an older version of `BibInternal` in their environment. Dealing with any resulting bugs in that case is on them.