### PR TITLE
Release 1.3.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -131,6 +131,11 @@ jobs:
           using Pkg
           VERSION = VersionNumber(Pkg.TOML.parsefile("Project.toml")["version"])
           BRANCH = ENV["GITHUB_REF_NAME"]
+          if ENV["GITHUB_EVENT_NAME"] == "pull_request"
+              # For pull_request events, return the head (aka., "from") branch,
+              # not the base (aka., "to") branch.
+              BRANCH = ENV["GITHUB_HEAD_REF"]
+          end
           if startswith(BRANCH, "release-")
               if (length(VERSION.prerelease) == length(VERSION.build))
                   println("Version $VERSION on release branch OK")

--- a/NEWS.md
+++ b/NEWS.md
@@ -4,7 +4,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
-## [Unreleased][]
+## [Version 1.3.0][1.3.0] - 2023-11-01
 
 ### Fixed
 
@@ -12,7 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Support underscores in citation keys [[#14][]]
 * The `Pages` in a `@bibliography` block are now relative to the folder containing the current file. The behavior is consistent with `Pages` in Documenter's `@index` and `@contents` blocks. [[#22][]]
 * The parsing of LaTeX strings has improved significantly. In particular, curly braces should now be stripped correctly [[#15][]]. Note that that braces in titles are never needed for `DocumenterCitations`, but handling them correctly makes it easier to use the same `.bib` file for LaTeX and `DocumenterCitations`.
-* Fixed the rendering of references other than `@article`, especially `@inproceedings`, `@incollection`, `@inbooks`, mimicking RevTeX. The DOI/URL are now linked via the Title and/or Booktitle. Added support for `Chapter`, `Volume`, `Number`, `Edition`, `Month` fields.
+* Fixed the rendering of references other than `@article`, especially `@inproceedings`, `@incollection`, `@inbooks`, mimicking RevTeX. The DOI/URL are now linked via the Title and/or Booktitle. Added support for `Chapter`, `Volume`, `Number`, `Edition`, `Month` fields. [[#56][]]
 
 ### Added
 
@@ -113,11 +113,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * [DocumenterCitations](https://github.com/JuliaDocs/DocumenterCitations.jl) is now hosted under the [JuliaDocs](https://github.com/JuliaDocs) organization.
 
 
-[Unreleased]: https://github.com/JuliaDocs/DocumenterCitations.jl/compare/v1.2.1...HEAD
+[Unreleased]: https://github.com/JuliaDocs/DocumenterCitations.jl/compare/v1.3.0...HEAD
+[1.3.0]: https://github.com/JuliaDocs/DocumenterCitations.jl/compare/v1.2.1...v1.3.0
 [1.2.1]: https://github.com/JuliaDocs/DocumenterCitations.jl/compare/v1.2.0...v1.2.1
 [1.2.0]: https://github.com/JuliaDocs/DocumenterCitations.jl/compare/v1.1.0...v1.2.0
 [1.1.0]: https://github.com/JuliaDocs/DocumenterCitations.jl/compare/v1.0.0...v1.1.0
 [1.0.0]: https://github.com/JuliaDocs/DocumenterCitations.jl/compare/v0.2.12...v1.0.0
+[#56]: https://github.com/JuliaDocs/DocumenterCitations.jl/pull/56
 [#53]: https://github.com/JuliaDocs/DocumenterCitations.jl/issues/53
 [#42]: https://github.com/JuliaDocs/DocumenterCitations.jl/pull/42
 [#40]: https://github.com/JuliaDocs/DocumenterCitations.jl/pull/40

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "DocumenterCitations"
 uuid = "daee34ce-89f3-4625-b898-19384cb65244"
 authors = ["Michael Goerz <mail@michaelgoerz.net>"]
-version = "1.2.1+dev"
+version = "1.3.0"
 
 [deps]
 AbstractTrees = "1520ce14-60c1-5f80-bbc7-55ef81b5835c"
@@ -17,7 +17,11 @@ Unicode = "4ec0a83e-493e-50e2-b9ac-8f72acf5a8f5"
 [compat]
 AbstractTrees = "0.4"
 Bibliography = "0.2.15"
+Dates = "1"
 Documenter = "1"
+Logging = "1"
+Markdown = "1"
 MarkdownAST = "0.1.2"
 OrderedCollections = "1.6"
+Unicode = "1"
 julia = "1.6"


### PR DESCRIPTION
This is a pretty big release, see [NEWS.md](https://github.com/JuliaDocs/DocumenterCitations.jl/blob/release-1.3.0/NEWS.md). To anyone relying on the [Internals](https://juliadocs.org/DocumenterCitations.jl/stable/internals/) for a custom style, it would be considered breaking. Hopefully, this will be the last release with such a significant change to the internals. If nothing comes up in the next couple of months, I would consider declaring the *documented* internals "stable" (covered by SemVer) in the `1.4.0` release, to be a bit more reliable for people with custom styles.