### PR TITLE
Warn about invalid bibtex

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 * Warn about markdown link syntax in `.bib` files [[#60][]]
+* Warn about invalid DOIs in `.bib` files. The DOI field should never contain a URL (`https://doi.org/...`). This is detected as a special case, and the DOI is extracted from the URL.
 
 
 ## [Version 1.3.1][1.3.1] - 2023-11-02

--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
+## [Unreleased][]
+
+### Fixed
+
+* Warn about markdown link syntax in `.bib` files [[#60][]]
+
+
 ## [Version 1.3.1][1.3.1] - 2023-11-02
 
 ### Fixed
@@ -142,6 +149,7 @@ There were several bugs and limitations in version `1.2.x` for which some existi
 [1.1.0]: https://github.com/JuliaDocs/DocumenterCitations.jl/compare/v1.0.0...v1.1.0
 [1.0.0]: https://github.com/JuliaDocs/DocumenterCitations.jl/compare/v0.2.12...v1.0.0
 [#61]: https://github.com/JuliaDocs/DocumenterCitations.jl/pull/61
+[#60]: https://github.com/JuliaDocs/DocumenterCitations.jl/issues/60
 [#59]: https://github.com/JuliaDocs/DocumenterCitations.jl/issues/59
 [#56]: https://github.com/JuliaDocs/DocumenterCitations.jl/pull/56
 [#53]: https://github.com/JuliaDocs/DocumenterCitations.jl/issues/53

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "DocumenterCitations"
 uuid = "daee34ce-89f3-4625-b898-19384cb65244"
 authors = ["Michael Goerz <mail@michaelgoerz.net>"]
-version = "1.3.1+dev"
+version = "1.3.2-dev"
 
 [deps]
 AbstractTrees = "1520ce14-60c1-5f80-bbc7-55ef81b5835c"

--- a/docs/src/refs.bib
+++ b/docs/src/refs.bib
@@ -427,7 +427,7 @@
     pages = {333--345},
     publisher = {Springer},
     title = {Design of Femtosecond Pulse Sequences to Control Photochemical Products},
-    doi = {0.1007/978-94-011-2642-7_23},
+    doi = {10.1007/978-94-011-2642-7_23},
     year = {1991},
 }
 

--- a/src/tex_to_markdown.jl
+++ b/src/tex_to_markdown.jl
@@ -123,6 +123,10 @@ end
 
 
 function tex_to_markdown(tex_str; transform_case=s -> s, debug=_DEBUG)
+    if contains(tex_str, "](http")
+        # https://github.com/JuliaDocs/DocumenterCitations.jl/issues/60
+        @warn "The tex string $(repr(tex_str)) appears to contain a link in markdown syntax. Links in a `.bib` entry should use the `\\href` tex command."
+    end
     try
         md_str = _process_tex(tex_str; transform_case=transform_case, debug=debug)
         return Unicode.normalize(md_str)

--- a/test/test_formatting/invalid_doi.bib
+++ b/test/test_formatting/invalid_doi.bib
@@ -1,0 +1,38 @@
+@string{njp = "New J. Phys."}
+@string{XXXclearparser = ""}
+
+
+% DOI shouldn't be a URL
+@article{Brif,
+    Author = {Brif, Constantin and Chakrabarti, Raj and Rabitz, Herschel},
+    Title = {Control of quantum phenomena: past, present and future},
+    Journal = njp,
+    Year = {2010},
+    Doi = {https://doi.org/10.1088/1367-2630/12/7/075008},
+    Pages = {075008},
+    Volume = {12},
+}
+
+
+% DOI has extra test
+@book{Shapiro,
+    author = {Shapiro, Moshe and Brumer, Paul},
+    edition = {Second},
+    publisher = {Wiley and Sons},
+    title = {Quantum Control of Molecular Processes},
+    year = {2012},
+    Doi = {doi:10.1002/9783527639700},
+}
+
+
+% DOI is missing first letter
+@incollection{Tannor,
+    author = {Tannor, David J. and Jin, Yijian},
+    booktitle = {Mode Selective Chemistry},
+    editor = {Jortner, J. and Levine, R. D. and Pullman, B.},
+    pages = {333--345},
+    publisher = {Springer},
+    title = {Design of Femtosecond Pulse Sequences to Control Photochemical Products},
+    doi = {0.1007/978-94-011-2642-7_23},
+    year = {1991},
+}

--- a/test/test_tex_to_markdown.jl
+++ b/test/test_tex_to_markdown.jl
@@ -324,6 +324,16 @@ end
     @test c.value.msg ==
           "Cannot evaluate \\href: ArgumentError(\"Unsupported command: \\\\error. Please report a bug.\")"
 
+    s = "The krotov Pyhon package is available on [Github](https://github.com/qucontrol/krotov)"
+    c = IOCapture.capture(rethrow=Union{}) do
+        tex_to_markdown(s)
+    end
+    @test c.value == s
+    @test contains(
+        c.output,
+        "Warning: The tex string \"The krotov Pyhon package is available on [Github](https://github.com/qucontrol/krotov)\" appears to contain a link in markdown syntax"
+    )
+
 end
 
 


### PR DESCRIPTION
Warn about markdown links and invalid DOIs in the `.bib` file, as discussed in https://github.com/JuliaDocs/DocumenterCitations.jl/issues/59#issuecomment-1789525803 and https://github.com/JuliaDocs/DocumenterCitations.jl/issues/60#issuecomment-1790537993