### PR TITLE
Add workflow to check `PkgEval`

### DIFF
--- a/.github/workflows/PkgEval.yml
+++ b/.github/workflows/PkgEval.yml
@@ -1,0 +1,39 @@
+name: PkgEval
+on:
+  push:
+    branches:
+      - pkgeval
+      - 'release-*'
+jobs:
+  test:
+    name: Check PkgEval
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+    steps:
+      - uses: julia-actions/setup-julia@v1
+        with:
+          version: '1'
+      - uses: actions/checkout@v4
+        with:
+          repository: 'JuliaCI/PkgEval.jl'
+      - name: Instantiate PkgEval
+        run: julia --project=. -e 'import Pkg; Pkg.instantiate()'
+      - name: Run PkgEval
+        shell: julia --project=. {0}
+        run: |
+          BRANCH = ENV["GITHUB_REF_NAME"]
+          using PkgEval
+          config = Configuration(; julia="nightly");
+          package = Package(; name="DocumenterCitations", rev=BRANCH)
+          println("##################################################")
+          @show config
+          @show package
+          println("##################################################")
+          result = PkgEval.evaluate_test(config, package; echo=true)
+          println("##################################################")
+          @show result.version
+          @show result.duration
+          @show result.status
+          @show result.reason
+          exit(result.status == :ok ? 0 : 1)

--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@
 [![Stable](https://img.shields.io/badge/docs-stable-blue.svg)](https://juliadocs.github.io/DocumenterCitations.jl/)
 [![Dev](https://img.shields.io/badge/docs-dev-blue.svg)](https://juliadocs.github.io/DocumenterCitations.jl/dev)
 [![Build Status](https://github.com/JuliaDocs/DocumenterCitations.jl/workflows/CI/badge.svg)](https://github.com/JuliaDocs/DocumenterCitations.jl/actions)
+[![PkgEval](https://juliahub.com/docs/General/DocumenterCitations/stable/pkgeval.svg)](https://juliaci.github.io/NanosoldierReports/pkgeval_badges/report.html)
 [![Coverage](https://codecov.io/gh/JuliaDocs/DocumenterCitations.jl/branch/master/graph/badge.svg)](https://codecov.io/gh/JuliaDocs/DocumenterCitations.jl)
 
 


### PR DESCRIPTION
"Nightly" is a pretty moving target, so it doesn't make sense to check `PkgEval` all the time. However, we do want to check before making a release (since JuliaHub displays a badge [based on the last release](https://discourse.julialang.org/t/how-does-the-pkgeval-badge-work-on-juliahub/105662)).

Thus, we add a workflow that runs on `release-*` branches. In addition, it also runs on a special `pkgeval` branch. So, to check the status of `PkgEval`, we can just push a branch of that name (without a PR).

Closes #50 