### PR TITLE
pass `article_link_doi_in_title` to `format_published_in` in `format_authoryear_bibliography_reference`

### DIFF
--- a/src/styles/authoryear.jl
+++ b/src/styles/authoryear.jl
@@ -164,7 +164,8 @@ function format_authoryear_bibliography_reference(
         entry;
         include_date=false,
         namesfmt=namesfmt,
-        title_transform_case=title_transform_case
+        title_transform_case=title_transform_case,
+        article_link_doi_in_title=article_link_doi_in_title
     )
     eprint = format_eprint(entry)
     urldate = format_urldate(entry; accessed_on=urldate_accessed_on, fmt=urldate_fmt)

--- a/test/test_formatting.jl
+++ b/test/test_formatting.jl
@@ -7,6 +7,7 @@ import DocumenterCitations:
     alpha_label,
     get_urls,
     doi_url,
+    format_authoryear_bibliography_reference,
     format_names,
     format_citation,
     format_bibliography_reference,
@@ -474,4 +475,19 @@ end
     )
     @test c.value == ""
 
+end
+
+
+@testset "Avoid double-linking of DOI in authoryear style (#87)" begin
+    bib = CitationBibliography(joinpath(splitext(@__FILE__)[1], "preprints.bib"))
+    b = bib.entries["NonStandardPreprint"]
+    md = format_authoryear_bibliography_reference(
+        :authoryear,
+        b,
+        article_link_doi_in_title=true
+    )
+    @test md !=
+          "Tomza, M.; Goerz, M. H.; Musiał, M.; Moszynski, R. and Koch, C. P. (2012). [*Optimized production of ultracold ground-state molecules: Stabilization employing potentials with ion-pair character and strong spin-orbit coupling*](https://doi.org/10.1103/PhysRevA.86.043424). [Phys. Rev. A **86**, 043424](https://doi.org/10.1103/PhysRevA.86.043424), xxx-preprint:1208.4331."
+    @Test md ==
+          "Tomza, M.; Goerz, M. H.; Musiał, M.; Moszynski, R. and Koch, C. P. (2012). [*Optimized production of ultracold ground-state molecules: Stabilization employing potentials with ion-pair character and strong spin-orbit coupling*](https://doi.org/10.1103/PhysRevA.86.043424). Phys. Rev. A **86**, 043424, xxx-preprint:1208.4331."
 end


### PR DESCRIPTION
This looked like an oversight because the argument name is the same in both functions.

The current behavior is this:
```julia
import DocumenterCitations
test_path = joinpath(dirname(dirname(pathof(DocumenterCitations))), "test/test_formatting/preprints.bib")
bib = DocumenterCitations.CitationBibliography(test_path)
b = first(values(bib.entries))


DocumenterCitations.format_published_in(b) # shows doi
DocumenterCitations.format_published_in(b, article_link_doi_in_title = true) # does not show doi

DocumenterCitations.format_authoryear_bibliography_reference(:authoryear, b) # shows doi around journal
DocumenterCitations.format_authoryear_bibliography_reference(:authoryear, b, article_link_doi_in_title = true) # shows doi around journal AND title
```
Showing the doi twice around both journal and title seems a bit odd to me. With this change the doi is shown around the journal when `article_link_doi_in_title = false` and around the title when `article_link_doi_in_title = true`.


feel free to close if this was intended behavior!
