### PR TITLE
Show error file paths consistently with Documenter

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased][]
 
+### Fixed
+
+* Show error file paths consistently with `Documenter`. With `Documenter < 1.10`, paths in error messages are relative to the `docs` folder. With `Documenter >= 1.10`, they are relative to the current working directory.
+
 
 ## [Version 1.3.6][1.3.6] - 2025-03-01
 

--- a/test/test_bibliography_block_pages.jl
+++ b/test/test_bibliography_block_pages.jl
@@ -1,4 +1,5 @@
 using DocumenterCitations
+import Documenter
 using Test
 
 include("run_makedocs.jl")
@@ -45,16 +46,24 @@ end
         check_success=true
     ) do dir, result, success, backtrace, output
 
+        rp = ""
+        if Documenter.DOCUMENTER_VERSION >= v"1.10.0"
+            # In v1.10, Documenter changed paths in error messages from being
+            # relative to `make.jl` to being relative to the CWD; see
+            # https://github.com/JuliaDocs/Documenter.jl/pull/2659
+            rp = relpath(realpath(dir)) * "/"
+        end
+
         @test success
         #! format: off
-        @test_broken contains(output, prx("Error: Invalid \"index.md\" in Pages attribute of @bibliography block on page src/part3/section2/invalidpages.md: No such file \"src/part3/section2/index.md\"."))
-        @test contains(output, prx("Warning: The entry \"index.md\" in the Pages attribute of the @bibliography block on page src/part3/section2/invalidpages.md appears to be relative to \"src\"."))
-        @test contains(output, prx("Error: Invalid \"p3_s1_page.md\" in Pages attribute of @bibliography block on page src/part3/section2/invalidpages.md: No such file \"src/part3/section2/p3_s1_page.md\"."))
-        @test contains(output, prx("Error: Invalid \"noexist.md\" in Pages attribute of @bibliography block on page src/part3/section2/invalidpages.md: No such file \"src/part3/section2/noexist.md\"."))
+        @test_broken contains(output, prx("Error: Invalid \"index.md\" in Pages attribute of @bibliography block on page $(rp)src/part3/section2/invalidpages.md: No such file \"src/part3/section2/index.md\"."))
+        @test contains(output, prx("Warning: The entry \"index.md\" in the Pages attribute of the @bibliography block on page $(rp)src/part3/section2/invalidpages.md:7-14 appears to be relative to \"src\"."))
+        @test contains(output, prx("Error: Invalid \"p3_s1_page.md\" in Pages attribute of @bibliography block on page $(rp)src/part3/section2/invalidpages.md:7-14: No such file \"src/part3/section2/p3_s1_page.md\"."))
+        @test contains(output, prx("Error: Invalid \"noexist.md\" in Pages attribute of @bibliography block on page $(rp)src/part3/section2/invalidpages.md:7-14: No such file \"src/part3/section2/noexist.md\"."))
         @test contains(output, "Warning: No cited keys remaining after filtering to Pages")
-        @test contains(output, prx("Error: Invalid \"../../addendum.md\" in Pages attribute of @bibliography block on page src/part3/section2/invalidpages.md: File \"src/addendum.md\" exists but no references were collected."))
-        @test contains(output, prx("Error: Invalid \"p3_s1_page.md\" in Pages attribute of @bibliography block on page src/part3/section2/invalidpages.md: No such file \"src/part3/section2/p3_s1_page.md\"."))
-        @test contains(output, prx("Warning: The field `Pages` in src/part3/section2/invalidpages.md:41-44 must evaluate to a list of strings. Setting invalid `Pages = \"none\"` to `Pages = []`"))
+        @test contains(output, prx("Error: Invalid \"../../addendum.md\" in Pages attribute of @bibliography block on page $(rp)src/part3/section2/invalidpages.md:20-25: File \"src/addendum.md\" exists but no references were collected."))
+        @test contains(output, prx("Error: Invalid \"p3_s1_page.md\" in Pages attribute of @bibliography block on page $(rp)src/part3/section2/invalidpages.md:29-35: No such file \"src/part3/section2/p3_s1_page.md\"."))
+        @test contains(output, prx("Warning: The field `Pages` in $(rp)src/part3/section2/invalidpages.md:41-44 must evaluate to a list of strings. Setting invalid `Pages = \"none\"` to `Pages = []`"))
         #! format: on
 
         build(paths...) = joinpath(dir, "build", paths...)
@@ -173,16 +182,24 @@ end
         check_failure=true
     ) do dir, result, success, backtrace, output
 
+        rp = ""
+        if Documenter.DOCUMENTER_VERSION >= v"1.10.0"
+            # In v1.10, Documenter changed paths in error messages from being
+            # relative to `make.jl` to being relative to the CWD; see
+            # https://github.com/JuliaDocs/Documenter.jl/pull/2659
+            rp = relpath(realpath(dir)) * "/"
+        end
+
         @test !success
         #! format: off
-        @test_broken contains(output, prx("Error: Invalid \"index.md\" in Pages attribute of @bibliography block on page src/part3/section2/invalidpages.md: No such file \"src/part3/section2/index.md\"."))
-        @test contains(output, prx("Warning: The entry \"index.md\" in the Pages attribute of the @bibliography block on page src/part3/section2/invalidpages.md appears to be relative to \"src\"."))
-        @test contains(output, prx("Error: Invalid \"p3_s1_page.md\" in Pages attribute of @bibliography block on page src/part3/section2/invalidpages.md: No such file \"src/part3/section2/p3_s1_page.md\"."))
-        @test contains(output, prx("Error: Invalid \"noexist.md\" in Pages attribute of @bibliography block on page src/part3/section2/invalidpages.md: No such file \"src/part3/section2/noexist.md\"."))
+        @test_broken contains(output, prx("Error: Invalid \"index.md\" in Pages attribute of @bibliography block on page $(rp)src/part3/section2/invalidpages.md:7-14: No such file \"src/part3/section2/index.md\"."))
+        @test contains(output, prx("Warning: The entry \"index.md\" in the Pages attribute of the @bibliography block on page $(rp)src/part3/section2/invalidpages.md:7-14 appears to be relative to \"src\"."))
+        @test contains(output, prx("Error: Invalid \"p3_s1_page.md\" in Pages attribute of @bibliography block on page $(rp)src/part3/section2/invalidpages.md:7-14: No such file \"src/part3/section2/p3_s1_page.md\"."))
+        @test contains(output, prx("Error: Invalid \"noexist.md\" in Pages attribute of @bibliography block on page $(rp)src/part3/section2/invalidpages.md:7-14: No such file \"src/part3/section2/noexist.md\"."))
         @test contains(output, "Warning: No cited keys remaining after filtering to Pages")
-        @test contains(output, prx("Error: Invalid \"../../addendum.md\" in Pages attribute of @bibliography block on page src/part3/section2/invalidpages.md: File \"src/addendum.md\" exists but no references were collected."))
-        @test contains(output, prx("Error: Invalid \"p3_s1_page.md\" in Pages attribute of @bibliography block on page src/part3/section2/invalidpages.md: No such file \"src/part3/section2/p3_s1_page.md\"."))
-        @test contains(output, prx("Warning: The field `Pages` in src/part3/section2/invalidpages.md:41-44 must evaluate to a list of strings. Setting invalid `Pages = \"none\"` to `Pages = []`"))
+        @test contains(output, prx("Error: Invalid \"../../addendum.md\" in Pages attribute of @bibliography block on page $(rp)src/part3/section2/invalidpages.md:20-25: File \"src/addendum.md\" exists but no references were collected."))
+        @test contains(output, prx("Error: Invalid \"p3_s1_page.md\" in Pages attribute of @bibliography block on page $(rp)src/part3/section2/invalidpages.md:29-35: No such file \"src/part3/section2/p3_s1_page.md\"."))
+        @test contains(output, prx("Warning: The field `Pages` in $(rp)src/part3/section2/invalidpages.md:41-44 must evaluate to a list of strings. Setting invalid `Pages = \"none\"` to `Pages = []`"))
         #! format: on
         @test result isa ErrorException
         @test occursin("`makedocs` encountered an error [:bibliography_block]", result.msg)


### PR DESCRIPTION
In v1.10, Documenter changed paths in error messages from being relative to `make.jl` to being relative to the CWD, via the internal `Documenter.locrepr` function. See https://github.com/JuliaDocs/Documenter.jl/pull/2659.

This PR consistenly uses `Documenter.locrepr` for file paths in error messages, ensuring that `DocumenterCitations` is consistent with `Documenter` both pre-1.10 and post-1.10. See https://github.com/JuliaDocs/Documenter.jl/pull/2667#issuecomment-2760402462.

As a side effect, the location of a `@bibliography` block containing errors is now shown including line numbers in more situations.