### PR TITLE
Use the `DocumenterCodeBlocks` plugin

### DIFF
--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -1,6 +1,7 @@
 [deps]
 Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
 DocumenterCitations = "daee34ce-89f3-4625-b898-19384cb65244"
+DocumenterCodeBlocks = "b6400b83-267f-4b55-9fd8-bffc853bdfd8"
 DocumenterInterLinks = "d12716ef-a0f6-4df4-a9f1-a5a34e75c656"
 LiveServer = "16fef848-5104-11e9-1b77-fb7a48bbb589"
 Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
@@ -9,5 +10,6 @@ Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
 DocumenterCitations = {path = ".."}
 
 [compat]
-Documenter = "1.4"
+Documenter = "1.17"
+DocumenterCodeBlocks = "1.3"
 julia = "1.11"

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -1,4 +1,5 @@
 using DocumenterCitations
+using DocumenterCodeBlocks
 using DocumenterInterLinks
 using Documenter
 using Pkg
@@ -13,6 +14,16 @@ bib = CitationBibliography(
     joinpath(@__DIR__, "src", "refs.bib");
     style=:numeric  # default
 )
+
+# Syntax highlighting, line numbers, and docstring reference links for the Julia
+# code blocks. `min_lines=3` keeps the gutter off the many one- and two-line
+# configuration snippets.
+codeblocks = CodeBlocks(; min_lines=3)
+
+# Tweak the built-in CSS for codeblocks: no underline at all until
+# hover, and then only a lightly dotted underline
+codeblocks_css = "assets/codeblocks.css"
+
 
 links = InterLinks(
     "Documenter" => "https://documenter.juliadocs.org/stable/",
@@ -34,8 +45,7 @@ makedocs(
     format=Documenter.HTML(
         prettyurls=true,
         canonical="https://juliadocs.org/DocumenterCitations.jl",
-        # No `assets=String["assets/citations.css"]`: the CSS for the citations
-        # is inserted automatically, see `DocumenterCitations.InjectAssets`.
+        assets=String[codeblocks_css],
         footer="[$NAME.jl]($GITHUB) v$VERSION docs powered by [Documenter.jl](https://github.com/JuliaDocs/Documenter.jl).",
     ),
     pages=[
@@ -46,7 +56,7 @@ makedocs(
         "Internals"              => "internals.md",
         "References"             => "references.md",
     ],
-    plugins=[bib, links],
+    plugins=[bib, links, codeblocks],
 )
 
 println("Finished makedocs")

--- a/docs/src/assets/codeblocks.css
+++ b/docs/src/assets/codeblocks.css
@@ -1,0 +1,21 @@
+/* Overrides for DocumenterCodeBlocks' `juliasyntax-tokens.css`.
+ *
+ * The plugin underlines reference links in code blocks with a dotted line at
+ * rest, going solid while the pointer is inside the block. We want no underline
+ * at rest, and the dotted line only on hover.
+ *
+ * The leading `html` is required: the plugin appends its stylesheet to
+ * `Documenter.HTML(assets=...)` during its own pipeline step, so it is loaded
+ * after this file and wins any tie on specificity.
+ */
+
+html pre code a.julia-ref {
+  text-decoration: none;
+}
+
+html pre:hover code a.julia-ref {
+  text-decoration: underline;
+  text-decoration-style: dotted;
+  text-decoration-color: color-mix(in srgb, currentColor 55%, transparent);
+  text-underline-offset: 2px;
+}

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -34,7 +34,7 @@ By default, [DocumenterCitations.jl](https://github.com/JuliaDocs/DocumenterCita
 
 You can install the latest version of [DocumenterCitations.jl](https://github.com/JuliaDocs/DocumenterCitations.jl) using the [built-in package manager](https://docs.julialang.org/en/v1/stdlib/Pkg/)
 
-```julia
+```julia-repl
 pkg> add DocumenterCitations
 ```
 

--- a/test/Project.toml
+++ b/test/Project.toml
@@ -19,16 +19,9 @@ SafeTestsets = "1bc83da4-3b8d-516f-aca4-4fe02f6d838f"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [sources]
-# Only honored on Julia >= 1.11. Local development (`make devrepl`) assumes
-# Julia >= 1.12.
 DocumenterCitations = {path = ".."}
 
 [compat]
-# The "Test Lower Compat Bounds" CI job resolves against these lower bounds, via
-# julia-actions/julia-downgrade-compat. Bounds for the package's own
-# dependencies live in the top-level `Project.toml` and define what this package
-# actually supports; the bounds here only need to be new enough to be useful and
-# old enough to remain compatible with those.
 DocumenterInterLinks = "1.0"
 IOCapture = "0.2.5, 1"
 JuliaFormatter = "1.0.62, 2"


### PR DESCRIPTION
This would greatly benefit from https://github.com/fredrikekre/DocumenterCodeBlocks.jl/pull/20 and https://github.com/fredrikekre/DocumenterCodeBlocks.jl/pull/15, but it's already pretty useful in its current form.

Tweaked as mentioned in https://github.com/fredrikekre/DocumenterCodeBlocks.jl/issues/21