### PR TITLE
Link back from the bibliography to the citations

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * An `insert_css` keyword argument for `CitationBibliography`. The default is `insert_css=true`. With `insert_css=false`, the bundled `citations.css` is not inserted, which gives full control over the CSS for citations and bibliographies to the `assets` of `Documenter.HTML`. [[#116][]]
 * A warning if any of the `assets` of `Documenter.HTML` is an unmodified copy of a `citations.css` bundled with some version of `DocumenterCitations`. Such a copy is redundant, as the stylesheet is now inserted automatically, and it would mask any future update of the bundled stylesheet. Customized stylesheets do not trigger the warning. [[#116][]]
 * Hovering over a citation link in the HTML documentation now shows the corresponding bibliography entry in a popup, similar to the footnote previews in `Documenter`. This is enabled by default; instantiate the plugin with `show_hover=false` to disable it. [[#67][], [#119][]]
+* Each entry in a canonical `@bibliography` block in the HTML documentation now ends with backlinks (`↩`) to the places where the reference is cited. After following a citation, the backlink that leads back to it is marked. This is enabled by default; instantiate the plugin with `show_backlinks=false` to disable it. [[#69][], [#120][]]
 
 
 ### Changed
@@ -238,6 +239,7 @@ There were several bugs and limitations in version `1.2.x` for which some existi
 [1.2.0]: https://github.com/JuliaDocs/DocumenterCitations.jl/compare/v1.1.0...v1.2.0
 [1.1.0]: https://github.com/JuliaDocs/DocumenterCitations.jl/compare/v1.0.0...v1.1.0
 [1.0.0]: https://github.com/JuliaDocs/DocumenterCitations.jl/compare/v0.2.12...v1.0.0
+[#120]: https://github.com/JuliaDocs/DocumenterCitations.jl/pull/120
 [#119]: https://github.com/JuliaDocs/DocumenterCitations.jl/pull/119
 [#117]: https://github.com/JuliaDocs/DocumenterCitations.jl/pull/117
 [#116]: https://github.com/JuliaDocs/DocumenterCitations.jl/pull/116
@@ -256,6 +258,7 @@ There were several bugs and limitations in version `1.2.x` for which some existi
 [#74]: https://github.com/JuliaDocs/DocumenterCitations.jl/pull/74
 [#73]: https://github.com/JuliaDocs/DocumenterCitations.jl/issues/73
 [#70]: https://github.com/JuliaDocs/DocumenterCitations.jl/pull/70
+[#69]: https://github.com/JuliaDocs/DocumenterCitations.jl/issues/69
 [#67]: https://github.com/JuliaDocs/DocumenterCitations.jl/issues/67
 [#65]: https://github.com/JuliaDocs/DocumenterCitations.jl/pull/65
 [#62]: https://github.com/JuliaDocs/DocumenterCitations.jl/pull/62

--- a/assets/citations-backlinks.js
+++ b/assets/citations-backlinks.js
@@ -47,47 +47,82 @@
     }
   }
 
-  // Mark the backlink that points at the citation with the given id, if the
-  // page has one. Any id that no backlink refers to is ignored, which is what
-  // keeps this from reacting to unrelated links.
-  function mark(id) {
+  function mark(backlink) {
     unmark();
-    if (!id) return;
+    if (!backlink) return;
+    backlink.classList.add(CLASS);
+    marked = backlink;
+  }
+
+  // The backlink pointing at the citation with the given id, if the page has
+  // one. Any id that no backlink refers to gives `null`, which is what keeps
+  // this from reacting to unrelated links.
+  function findBacklink(id) {
+    if (!id) return null;
     var backlinks = document.querySelectorAll(".citation-backlinks a");
     for (var i = 0; i < backlinks.length; i++) {
-      if (backlinks[i].hash === "#" + id) {
-        backlinks[i].classList.add(CLASS);
-        marked = backlinks[i];
-        return;
-      }
+      if (backlinks[i].hash === "#" + id) return backlinks[i];
     }
+    return null;
+  }
+
+  // The name of the anchor of the bibliography entry containing the given
+  // backlink, i.e., the target of the citations of that reference
+  function entryOf(backlink) {
+    var element = backlink;
+    while (element) {
+      if (element.id) return element.id;
+      element = element.parentNode;
+    }
+    return "";
+  }
+
+  // Whether following the given link means following a citation. Carrying an
+  // `id` is not sufficient: `Documenter` gives one to some of its own
+  // controls, e.g., the settings button, and clicking those must not be
+  // remembered as a citation (nor unmark the backlink of an actual one). A
+  // citation also links to the anchor of the bibliography entry.
+  function isCitation(link) {
+    return Boolean(link.id) && Boolean(link.hash);
+  }
+
+  // Mark the backlink for the citation remembered from an earlier click, but
+  // only if the reader has in fact arrived at the entry that this citation
+  // links to. Coming to the bibliography by other means — the sidebar, the
+  // search, a link to a section — shows all backlinks alike, even though the
+  // citation followed earlier in the session is still remembered.
+  function markOnArrival() {
+    var backlink = findBacklink(readFollowed());
+    if (backlink && "#" + entryOf(backlink) !== window.location.hash) {
+      backlink = null;
+    }
+    mark(backlink);
   }
 
   function init() {
-    // A click on a citation records where to come back to. The link is not
-    // checked for being a citation: `mark` only reacts to an id that some
-    // backlink points at.
+    // A click on a citation records where to come back to
     document.addEventListener("click", function (e) {
       var element = e.target;
       while (element && element !== document) {
         if (element.tagName === "A") {
-          if (element.id) {
+          if (isCitation(element)) {
             writeFollowed(element.id);
             // With the bibliography on the same page as the citation there is
-            // no page load that would pick the id up again
-            mark(element.id);
+            // no page load that would pick the id up again. The hash is only
+            // updated after this handler has run, so `markOnArrival` cannot be
+            // used here — but a click on a citation is arrival enough.
+            mark(findBacklink(element.id));
           }
           return;
         }
         element = element.parentNode;
       }
     });
-    mark(readFollowed());
+    markOnArrival();
     // Following a backlink, or any other jump within the page, leaves the mark
-    // in place: it still shows where the reader came from
-    window.addEventListener("pageshow", function () {
-      mark(readFollowed());
-    });
+    // in place: it still shows where the reader came from. Coming back through
+    // the history restores it, for a page served from the back/forward cache.
+    window.addEventListener("pageshow", markOnArrival);
   }
 
   if (document.readyState === "loading") {

--- a/assets/citations-backlinks.js
+++ b/assets/citations-backlinks.js
@@ -1,0 +1,98 @@
+/* Marking the backlink that leads back to the citation the reader came from —
+ * DocumenterCitations.
+ *
+ * Every citation link carries the `id` that the backlinks at the end of the
+ * corresponding bibliography entry point to. Following a citation therefore
+ * identifies one particular backlink, but the browser cannot express that: the
+ * link targets the entry as a whole, and nothing in the resulting page says
+ * which of the entry's backlinks is the way back.
+ *
+ * So the id of the followed citation is remembered in `sessionStorage` (the
+ * bibliography is usually on a different page, which rules out passing it in a
+ * variable), and the backlink pointing to it is given the class
+ * `is-current-citation`, styled in `citations.css`. Without JavaScript, or
+ * when the reader arrives at the bibliography by other means, the backlinks
+ * are simply all shown alike.
+ */
+(function () {
+  "use strict";
+
+  var CLASS = "is-current-citation";
+  var STORAGE_KEY = "documentercitations-followed-citation";
+
+  var marked = null; // the backlink currently carrying the class
+
+  // `sessionStorage` throws in a browser that blocks storage, and is absent
+  // for a page opened from the file system in some browsers
+  function readFollowed() {
+    try {
+      return window.sessionStorage.getItem(STORAGE_KEY);
+    } catch (e) {
+      return null;
+    }
+  }
+
+  function writeFollowed(id) {
+    try {
+      window.sessionStorage.setItem(STORAGE_KEY, id);
+    } catch (e) {
+      /* not being able to remember it only means no backlink is marked */
+    }
+  }
+
+  function unmark() {
+    if (marked) {
+      marked.classList.remove(CLASS);
+      marked = null;
+    }
+  }
+
+  // Mark the backlink that points at the citation with the given id, if the
+  // page has one. Any id that no backlink refers to is ignored, which is what
+  // keeps this from reacting to unrelated links.
+  function mark(id) {
+    unmark();
+    if (!id) return;
+    var backlinks = document.querySelectorAll(".citation-backlinks a");
+    for (var i = 0; i < backlinks.length; i++) {
+      if (backlinks[i].hash === "#" + id) {
+        backlinks[i].classList.add(CLASS);
+        marked = backlinks[i];
+        return;
+      }
+    }
+  }
+
+  function init() {
+    // A click on a citation records where to come back to. The link is not
+    // checked for being a citation: `mark` only reacts to an id that some
+    // backlink points at.
+    document.addEventListener("click", function (e) {
+      var element = e.target;
+      while (element && element !== document) {
+        if (element.tagName === "A") {
+          if (element.id) {
+            writeFollowed(element.id);
+            // With the bibliography on the same page as the citation there is
+            // no page load that would pick the id up again
+            mark(element.id);
+          }
+          return;
+        }
+        element = element.parentNode;
+      }
+    });
+    mark(readFollowed());
+    // Following a backlink, or any other jump within the page, leaves the mark
+    // in place: it still shows where the reader came from
+    window.addEventListener("pageshow", function () {
+      mark(readFollowed());
+    });
+  }
+
+  if (document.readyState === "loading") {
+    document.addEventListener("DOMContentLoaded", init);
+  } else {
+    init();
+  }
+})();

--- a/assets/citations-hover.js
+++ b/assets/citations-hover.js
@@ -36,6 +36,7 @@
   var trigger = null; // the link the popup currently belongs to
   var pageURL = {}; // anchor name -> absolute URL of the bibliography page
   var pageKey = {}; // anchor name -> that URL in the form used for comparison
+  var jumpedTo = null; // citation whose jump-focus was already skipped
 
   // A form of the URL that identifies the page, for comparing a link with the
   // recorded path of a bibliography page: without the fragment, and with a
@@ -166,11 +167,25 @@
   }
 
   // Keyboard focus shows the popup without delay, so that a screen reader
-  // picks up the `aria-describedby` description when it announces the link
+  // picks up the `aria-describedby` description when it announces the link.
+  //
+  // Following a link *to* a citation, e.g. one of the backlinks at the end of
+  // a bibliography entry, also focuses it. That must not open a popup: the
+  // reader asked to be taken to the citation, not to be shown the entry they
+  // are coming from. Only the first focus is skipped, so that tabbing back to
+  // the link later still describes it.
   function onLinkFocus(e) {
+    var link = e.currentTarget;
+    // The hash is up to date by the time the focus event fires (`hashchange`
+    // only comes afterwards), so the link being the current fragment target
+    // identifies the focus as the one that follows the jump
+    if (link.id && "#" + link.id === window.location.hash && link.id !== jumpedTo) {
+      jumpedTo = link.id;
+      return;
+    }
     cancelHide();
     if (showTimer) clearTimeout(showTimer);
-    showPopupFor(e.currentTarget);
+    showPopupFor(link);
   }
 
   function init() {
@@ -195,6 +210,9 @@
       found = true;
     });
     if (!found) return; // no citations on this page
+    window.addEventListener("hashchange", function () {
+      jumpedTo = null;
+    });
     document.addEventListener("keydown", function (e) {
       if (e.key === "Escape") hidePopup();
     });

--- a/assets/citations-hover.js
+++ b/assets/citations-hover.js
@@ -210,8 +210,13 @@
       found = true;
     });
     if (!found) return; // no citations on this page
+    // The jump fires `hashchange` right after the focus it caused, so the
+    // state that focus has just set must survive it: the reader is still at
+    // that citation, and tabbing back to it should describe it. Moving on to
+    // another fragment does clear the state, so that returning to the citation
+    // later is again recognized as a jump.
     window.addEventListener("hashchange", function () {
-      jumpedTo = null;
+      if ("#" + jumpedTo !== window.location.hash) jumpedTo = null;
     });
     document.addEventListener("keydown", function (e) {
       if (e.key === "Escape") hidePopup();

--- a/assets/citations.css
+++ b/assets/citations.css
@@ -15,3 +15,9 @@
  margin: 0.33em 0.5em 0.5em 2.25em;}
 .citation ol li {
  padding-left:0.75em;}
+.citation .citation-backlinks a {
+ white-space: nowrap;
+ text-decoration: none;}
+.citation .citation-backlinks a.is-current-citation {
+ outline: 1px solid currentColor;
+ border-radius: 3px;}

--- a/docs/src/internals.md
+++ b/docs/src/internals.md
@@ -18,7 +18,7 @@ The [`DocumenterCitations.CitationBibliography`](@ref) plugin hooks into the [`D
 2. [`ExpandBibliography`](@ref)
 3. [`ExpandCitations`](@ref)
 
-In addition, the plugin adds a fourth step, [`InjectAssets`](@ref), which runs just before [`RenderDocument`](https://documenter.juliadocs.org/stable/lib/internals/builder/#Documenter.Builder.RenderDocument) and inserts the assets for the [CSS styling](@ref "CSS Styling") of the rendered citations and bibliographies and for the [citation hover popups](@ref "Citation hover popups"). A fifth step, [`WriteHoverData`](@ref), runs after `RenderDocument` and writes the data for those popups.
+In addition, the plugin adds a fourth step, [`InjectAssets`](@ref), which runs just before [`RenderDocument`](https://documenter.juliadocs.org/stable/lib/internals/builder/#Documenter.Builder.RenderDocument) and inserts the assets for the [CSS styling](@ref "CSS Styling") of the rendered citations and bibliographies, for the [citation hover popups](@ref "Citation hover popups"), and for the marking of the followed citation in the [bibliography backlinks](@ref "Bibliography backlinks"). A fifth step, [`WriteHoverData`](@ref), runs after `RenderDocument` and writes the data for the popups.
 
 
 ```@docs

--- a/docs/src/styling.md
+++ b/docs/src/styling.md
@@ -58,3 +58,16 @@ bib = CitationBibliography("refs.bib"; show_hover=false)
 ```
 
 This is independent of the `insert_css` option.
+
+
+## Bibliography backlinks
+
+Every entry in a [canonical `@bibliography` block](@ref canonical) ends with a list of backlinks (`↩`) to the places where the reference is cited, in the order in which the citations appear in the documentation. Hovering over a backlink names the section it leads to. See the [References](@ref) for how this looks for a reference that is cited a few dozen times.
+
+After following a citation, the backlink that leads back to it is outlined, so that it can be picked out among the others. The outline is applied by the bundled [`citations-backlinks.js`](https://github.com/JuliaDocs/DocumenterCitations.jl/blob/master/assets/citations-backlinks.js), which adds the class `is-current-citation` to that backlink; the styling is part of `citations.css`. Readers without JavaScript, and readers who reach the bibliography by other means than following a citation, see all backlinks alike. To omit the backlinks:
+
+```julia
+bib = CitationBibliography("refs.bib"; show_backlinks=false)
+```
+
+The backlinks are an HTML feature: they never appear in the LaTeX output.

--- a/src/DocumenterCitations.jl
+++ b/src/DocumenterCitations.jl
@@ -52,8 +52,9 @@ keyword argument to [`Documenter.makedocs`](@extref).
   [Citation hover popups](@ref). Set this to `false` to disable the popups.
 * `show_backlinks`: whether each entry in a canonical `@bibliography` block in
   the HTML documentation ends with a list of backlinks (`↩`) to the places
-  where the reference is cited. After following a citation, the backlink that
-  leads back to it is marked. Set this to `false` to omit the backlinks.
+  where the reference is cited, see [Bibliography backlinks](@ref). After
+  following a citation, the backlink that leads back to it is marked. Set this
+  to `false` to omit the backlinks.
 
 # Internal fields
 

--- a/src/DocumenterCitations.jl
+++ b/src/DocumenterCitations.jl
@@ -20,11 +20,17 @@ using Dates: Dates, @dateformat_str
 
 export CitationBibliography
 
+# `CitationSite` is a field type of `CitationBibliography` and thus must be
+# defined before it. All other files are included at the end of the module.
+include("citation_site.jl")
+
 
 """Plugin for enabling bibliographic citations in Documenter.jl.
 
 ```julia
-bib = CitationBibliography(bibfile; style=:numeric, insert_css=true, show_hover=true)
+bib = CitationBibliography(
+    bibfile; style=:numeric, insert_css=true, show_hover=true, show_backlinks=true
+)
 ```
 
 instantiates a plugin object that must be passed as an element of the `plugins`
@@ -44,6 +50,10 @@ keyword argument to [`Documenter.makedocs`](@extref).
 * `show_hover`: whether hovering over a citation link in the HTML
   documentation shows the corresponding bibliography entry in a popup, see
   [Citation hover popups](@ref). Set this to `false` to disable the popups.
+* `show_backlinks`: whether each entry in a canonical `@bibliography` block in
+  the HTML documentation ends with a list of backlinks (`↩`) to the places
+  where the reference is cited. After following a citation, the backlink that
+  leads back to it is marked. Set this to `false` to omit the backlinks.
 
 # Internal fields
 
@@ -65,6 +75,10 @@ should not be considered part of the stable API.
   bibliography entry and the path of the page containing it. Collected during
   HTML rendering and written out by
   [`DocumenterCitations.WriteHoverData`](@ref).
+* `backlinks`: dict of anchor name to the list of
+  `DocumenterCitations.CitationSite` objects for the places where the
+  corresponding reference is cited, in the order in which the citations appear
+  in the documentation. Collected by [`ExpandCitations`](@ref).
 """
 struct CitationBibliography <: Documenter.Plugin
 
@@ -81,6 +95,10 @@ struct CitationBibliography <: Documenter.Plugin
     # whether to show bibliography entries in popups when hovering over
     # citation links (HTML only)
     show_hover::Bool
+
+    # whether to show backlinks from the bibliography to the citations
+    # (HTML only)
+    show_backlinks::Bool
 
     # citation key => entry (set on instantiation; private)
     entries::OrderedDict{String,<:Bibliography.AbstractEntry}
@@ -103,13 +121,18 @@ struct CitationBibliography <: Documenter.Plugin
     # bibliography block, relative to the root of the site); private
     hover_entries::Dict{String,Tuple{String,String}}
 
+    # anchor name => list of places where the reference is cited, in the order
+    # in which the citations appear in the documentation; private
+    backlinks::Dict{String,Vector{CitationSite}}
+
 end
 
 function CitationBibliography(
     bibfile::AbstractString="";
     style=nothing,
     insert_css=true,
-    show_hover=true
+    show_hover=true,
+    show_backlinks=true
 )
     if isnothing(style)
         style = :numeric
@@ -155,17 +178,20 @@ function CitationBibliography(
     anchor_map = Documenter.AnchorMap()
     anchor_keys = Bijections.Bijection{String,String}()
     hover_entries = Dict{String,Tuple{String,String}}()
+    backlinks = Dict{String,Vector{CitationSite}}()
     return CitationBibliography(
         bibfile,
         style,
         insert_css,
         show_hover,
+        show_backlinks,
         entries,
         citations,
         page_citations,
         anchor_map,
         anchor_keys,
-        hover_entries
+        hover_entries,
+        backlinks
     )
 end
 

--- a/src/assets.jl
+++ b/src/assets.jl
@@ -54,7 +54,7 @@ _asset_uri(filename) = "assets/$ASSETS_SUBFOLDER/$filename"
 # format object
 function inject_assets!(doc::Documenter.Document)
     bib = Documenter.getplugin(doc, CitationBibliography)
-    (bib.insert_css || bib.show_hover) || return  # nothing to inject
+    (bib.insert_css || bib.show_hover || bib.show_backlinks) || return  # nothing to do
     html = _find_html_format(doc.user.format)
     isnothing(html) && return  # no HTML output
     destination = joinpath(doc.user.build, "assets", ASSETS_SUBFOLDER)
@@ -74,6 +74,9 @@ function inject_assets!(doc::Documenter.Document)
         # already here. It must come before the script that reads it.
         _register_asset!(html, _asset_uri(HOVER_DATA_FILENAME))
         _insert_asset!(html, "citations-hover.js", destination)
+    end
+    if bib.show_backlinks
+        _insert_asset!(html, "citations-backlinks.js", destination)
     end
     return
 end
@@ -154,7 +157,8 @@ _css_hash(str::AbstractString) = bytes2hex(sha256(_normalize_css(str)))
 # `test/test_assets.jl` fails if the first entry does not match the current
 # `assets/citations.css`.
 const KNOWN_CSS_HASHES = (
-    "ad197a59c8c6e614024dd464d9b9693a0ab5bb8479bcb2c1d423fb30ff7ee87b",  # since v1.3.3
+    "bc8cdcc413ba5b92d6547a7185bcb7fe02d8df6b3879a18b25d28b64cddb8e40",  # since v1.5.0
+    "ad197a59c8c6e614024dd464d9b9693a0ab5bb8479bcb2c1d423fb30ff7ee87b",  # v1.3.3 – v1.4.1
     "f2986976ab24cbac4d387e85c0c87c297591d0a153160913ee4bf01551402763",  # v1.0 – v1.3.2
     "a84156754fe3efcce021d9be813b2d3fa4e1cd83ef5669e9aac013c44b543b74",  # before v1.0
 )

--- a/src/assets.jl
+++ b/src/assets.jl
@@ -11,11 +11,16 @@ The assets shipped with the package are copied into
 [`Documenter.HTML`](@extref Documenter.HTMLWriter.HTML) format, so that
 `Documenter` emits the corresponding `<link>` and `<script>` tags in the
 `<head>` of every page. Thus, no manual `assets` entry is required in
-[`Documenter.makedocs`](@extref). These are the `citations.css` stylesheet
-(unless the [`CitationBibliography`](@ref) plugin was instantiated with
-`insert_css=false`) and the stylesheet and script for the [Citation hover
-popups](@ref) (unless `show_hover=false`). The two options are independent of
-each other.
+[`Documenter.makedocs`](@extref). These are
+
+* the `citations.css` stylesheet, unless the [`CitationBibliography`](@ref)
+  plugin was instantiated with `insert_css=false`,
+* the stylesheet and the script for the [Citation hover popups](@ref), unless
+  `show_hover=false`,
+* the script that marks the followed citation in the [Bibliography
+  backlinks](@ref), unless `show_backlinks=false`.
+
+The three options are independent of each other.
 
 Stylesheets are inserted *before* any user-defined assets, so that custom CSS
 still takes precedence over the bundled ones, see [CSS Styling](@ref).

--- a/src/bibliography_node.jl
+++ b/src/bibliography_node.jl
@@ -66,7 +66,7 @@ end
 
 
 function domify_bib(dctx::Documenter.HTMLWriter.DCtx, bibliography::BibliographyNode)
-    Documenter.DOM.@tags dl ul ol li div dt dd
+    Documenter.DOM.@tags dl ul ol li div dt dd span sup a
     list_tag = dl
     if bibliography.list_style == :ul
         list_tag = ul
@@ -78,21 +78,45 @@ function domify_bib(dctx::Documenter.HTMLWriter.DCtx, bibliography::Bibliography
     # Collect the rendered entries for the hover popups (`WriteHoverData`).
     # Only canonical blocks define anchors, and thus link targets to hover over
     capture_hover = bib.show_hover && bibliography.canonical
-    page = ""
-    if capture_hover
-        # the page being rendered, relative to the root of the site (the
-        # separators are normalized for the benefit of Windows)
-        url = Documenter.HTMLWriter.get_url(dctx.ctx, dctx.navnode)
-        page = replace(url, '\\' => '/')
-    end
+    # Only canonical blocks list the places where a reference is cited
+    show_backlinks = bib.show_backlinks && bibliography.canonical
+    url = Documenter.HTMLWriter.get_url(dctx.ctx, dctx.navnode)
+    # the page being rendered, relative to the root of the site (the separators
+    # are normalized for the benefit of Windows)
+    page = replace(url, '\\' => '/')
     for item in bibliography.items
         anchor_id = isnothing(item.anchor_key) ? "" : "#$(item.anchor_key)"
         html_reference = Documenter.HTMLWriter.domify(dctx, item.reference.children)
         if capture_hover && !isnothing(item.anchor_key)
             # Note that we store the rendered entry only, without the
             # surrounding `div` that carries the anchor: the popup content must
-            # not duplicate any element ID
+            # not duplicate any element ID. The backlinks are appended after
+            # this, so that they do not show up in the popups either
             bib.hover_entries[item.anchor_key] = (join(string.(html_reference)), page)
+        end
+        if show_backlinks && !isnothing(item.anchor_key)
+            sites = get(bib.backlinks, item.anchor_key, CitationSite[])
+            backlinks = []
+            for (i, site) in enumerate(sites)
+                href = Documenter.HTMLWriter.pretty_url(
+                    dctx.ctx,
+                    Documenter.HTMLWriter.relhref(
+                        url,
+                        Documenter.HTMLWriter.get_url(dctx.ctx, site.src)
+                    )
+                )
+                attributes = Pair{Symbol,String}[:href=>"$href#$(site.id)"]
+                if !isempty(site.section)
+                    push!(attributes, :title => "Cited in $(site.section)")
+                end
+                # The space separates the backlinks and, for a reference that
+                # is cited very often, allows them to wrap onto the next line
+                push!(backlinks, " ")
+                push!(backlinks, a[attributes...]("↩", sup(string(i))))
+            end
+            if !isempty(backlinks)
+                push!(html_reference, span[".citation-backlinks"](backlinks))
+            end
         end
         if bibliography.list_style == :dl
             html_label = Documenter.HTMLWriter.domify(dctx, item.label.children)

--- a/src/citation_site.jl
+++ b/src/citation_site.jl
@@ -1,0 +1,73 @@
+"""A place in the documentation where a reference is cited.
+
+# Properties
+
+* `src`: the name of the markdown file containing the citation, relative to
+  `doc.user.source`
+* `id`: the name of the HTML anchor at the citation, see
+  [`CitationSiteNode`](@ref)
+* `section`: the title of the section containing the citation, or an empty
+  string if the citation is not inside any section
+
+The citation sites for each reference are collected in the `backlinks`
+attribute of the internal [`CitationBibliography`](@ref) object, and are
+rendered as backlinks at the end of the corresponding entry in a canonical
+`@bibliography` block.
+"""
+struct CitationSite
+    src::String
+    id::String
+    section::String
+end
+
+
+"""Node in `MarkdownAST` that gives an HTML anchor to a citation.
+
+# Properties
+
+* `id`: the name of the anchor, which becomes the `id` attribute of the `<a>`
+  tag of the citation link that is the child of the node
+
+The node wraps the link of a single expanded citation, so that the backlinks
+in the bibliography can point to the exact place of the citation. It is
+transparent in any output format other than HTML.
+"""
+struct CitationSiteNode <: MarkdownAST.AbstractInline
+    id::String
+end
+
+MarkdownAST.iscontainer(::CitationSiteNode) = true
+
+
+function Documenter.HTMLWriter.domify(
+    dctx::Documenter.HTMLWriter.DCtx,
+    node::Documenter.Node,
+    citation_site::CitationSiteNode
+)
+    @assert node.element === citation_site
+    dom = Documenter.HTMLWriter.domify(dctx, node.children)
+    for element in dom
+        if element isa Documenter.DOM.Node && element.name === :a
+            # `Documenter.DOM.Node` is immutable, but its `attributes` are not
+            push!(element.attributes, :id => citation_site.id)
+            break
+        end
+    end
+    # If there is no link (`droplinks` is set for the search index), the
+    # citation is rendered as plain text, without an anchor
+    return dom
+end
+
+
+function Documenter.LaTeXWriter.latex(
+    lctx::Documenter.LaTeXWriter.Context,
+    node::MarkdownAST.Node,
+    ::CitationSiteNode
+)
+    return Documenter.LaTeXWriter.latex(lctx, node.children)
+end
+
+
+function Documenter.MDFlatten.mdflatten(io, node::MarkdownAST.Node, ::CitationSiteNode)
+    return Documenter.MDFlatten.mdflatten(io, node.children)
+end

--- a/src/expand_citations.jl
+++ b/src/expand_citations.jl
@@ -38,34 +38,67 @@ function expand_citations!(doc::Documenter.Document)
 end
 
 # Expand all citations in one page (modify `mdast` in-place). The `section` is
-# the title of the section that contains the citations, tracked for the
-# backlinks. Since `replace!` traverses the children of any node before the
-# node itself, a heading is always processed before the citations that follow
-# it.
+# the title of the section containing any citation that is not preceded by a
+# heading (the name of the docstring anchor, for a docstring AST).
 function expand_citations!(
     doc::Documenter.Document,
     page,
     mdast::MarkdownAST.Node,
     src,
-    section=Ref("")
+    section=""
 )
     bib = Documenter.getplugin(doc, CitationBibliography)
+    sections = citation_sections(mdast, section)
     replace!(mdast) do node
-        if node.element isa Documenter.AnchoredHeader
-            section[] = Documenter.MDFlatten.mdflatten(first(node.children))
-            node
-        elseif node.element isa Documenter.DocsNode
+        if node.element isa Documenter.DocsNode
             # The docstring AST trees are not part of the tree of the page, so
             # we need to expand them explicitly
-            docstring_section = Ref(node.element.anchor.id)
             for (docstr, meta) in zip(node.element.mdasts, node.element.metas)
-                expand_citations!(doc, page, docstr, src, docstring_section)
+                expand_citations!(doc, page, docstr, src, node.element.anchor.id)
             end
             node
         else
-            expand_citation(node, page, bib; src=src, section=section[])
+            expand_citation(
+                node,
+                page,
+                bib;
+                src=src,
+                section=get(sections, node.element, section)
+            )
         end
     end
+end
+
+
+# Map the element of every link in `mdast` to the title of the section that
+# contains it, for the backlinks.
+#
+# This has to happen before the expansion: `replace!` traverses the children of
+# a node before the node itself, so tracking the current heading while
+# expanding would attribute a citation *inside* a heading to the preceding
+# section, and would flatten the heading only after the citations in it had
+# been replaced by their rendered form.
+#
+# Note that the elements of the nodes are shared between the tree that
+# `replace!` walks and the tree given here, which is what allows the result to
+# be used as a lookup table during the expansion.
+function citation_sections(mdast::MarkdownAST.Node, section="")
+    sections = IdDict{MarkdownAST.AbstractElement,String}()
+    _citation_sections!(sections, mdast, section)
+    return sections
+end
+
+function _citation_sections!(sections, node::MarkdownAST.Node, section)
+    for child in node.children
+        if child.element isa Documenter.AnchoredHeader
+            # A citation in the heading belongs to the section it opens
+            section = Documenter.MDFlatten.mdflatten(first(child.children))
+        elseif child.element isa MarkdownAST.Link
+            sections[child.element] = section
+        end
+        _citation_sections!(sections, child, section)
+    end
+    return sections
 end
 
 

--- a/src/expand_citations.jl
+++ b/src/expand_citations.jl
@@ -22,26 +22,48 @@ end
 
 # Expand all citations in document
 function expand_citations!(doc::Documenter.Document)
-    for (src, page) in doc.blueprint.pages
+    bib = Documenter.getplugin(doc, CitationBibliography)
+    empty!(bib.backlinks)  # so that repeated builds give identical results
+    # We walk the pages in the same order as `CollectCitations`, so that the
+    # backlinks of each reference are in the order in which the citations
+    # appear in the documentation
+    nav_sources = [node.page for node in doc.internal.navlist]
+    other_sources = filter(src -> !(src in nav_sources), keys(doc.blueprint.pages))
+    for src in Iterators.flatten([nav_sources, other_sources])
+        page = doc.blueprint.pages[src]
         @debug "ExpandCitations: resolving links and replacement text for @cite entries in $(src)"
         empty!(page.globals.meta)
-        expand_citations!(doc, page, page.mdast)
+        expand_citations!(doc, page, page.mdast, src)
     end
 end
 
-# Expand all citations in one page (modify `mdast` in-place)
-function expand_citations!(doc::Documenter.Document, page, mdast::MarkdownAST.Node)
+# Expand all citations in one page (modify `mdast` in-place). The `section` is
+# the title of the section that contains the citations, tracked for the
+# backlinks. Since `replace!` traverses the children of any node before the
+# node itself, a heading is always processed before the citations that follow
+# it.
+function expand_citations!(
+    doc::Documenter.Document,
+    page,
+    mdast::MarkdownAST.Node,
+    src,
+    section=Ref("")
+)
     bib = Documenter.getplugin(doc, CitationBibliography)
     replace!(mdast) do node
-        if node.element isa Documenter.DocsNode
+        if node.element isa Documenter.AnchoredHeader
+            section[] = Documenter.MDFlatten.mdflatten(first(node.children))
+            node
+        elseif node.element isa Documenter.DocsNode
             # The docstring AST trees are not part of the tree of the page, so
             # we need to expand them explicitly
+            docstring_section = Ref(node.element.anchor.id)
             for (docstr, meta) in zip(node.element.mdasts, node.element.metas)
-                expand_citations!(doc, page, docstr)
+                expand_citations!(doc, page, docstr, src, docstring_section)
             end
             node
         else
-            expand_citation(node, page, bib)
+            expand_citation(node, page, bib; src=src, section=section[])
         end
     end
 end
@@ -96,6 +118,8 @@ function expand_citation(
     node::MarkdownAST.Node,
     page,
     bib::CitationBibliography;
+    src="",       # name of the page file, for the backlinks
+    section="",   # title of the section containing the citation
     _recursive=true  # internal: expand each expanded sibling again?
 )
     (node.element isa MarkdownAST.Link) || return node
@@ -121,7 +145,14 @@ function expand_citation(
         end
         expanded_nodes = []
         for sibling in expanded_nodes1
-            expanded_sibling = expand_citation(sibling, page, bib; _recursive=false)
+            expanded_sibling = expand_citation(
+                sibling,
+                page,
+                bib;
+                src=src,
+                section=section,
+                _recursive=false
+            )
             if expanded_sibling isa Vector
                 append!(expanded_nodes, expanded_sibling)
             else
@@ -141,6 +172,16 @@ function expand_citation(
             expanded_node.element.destination =
                 string(path, Documenter.anchor_fragment(anchor))
             @debug "expand_citation$rec: $cit → link to $(expanded_node.element.destination)"
+            if bib.show_backlinks
+                # Wrap the link in a node that gives it an HTML anchor, so that
+                # the bibliography can link back to this exact citation
+                sites = get!(bib.backlinks, anchor_key, CitationSite[])
+                id = "$(anchor_key)-cite-$(length(sites) + 1)"
+                push!(sites, CitationSite(src, id, section))
+                citation_site = MarkdownAST.Node(CitationSiteNode(id))
+                push!(citation_site.children, expanded_node)
+                return citation_site
+            end
             return expanded_node
         else
             link_text = ast_linktext(cit.node)

--- a/test/js/dom.js
+++ b/test/js/dom.js
@@ -1,0 +1,136 @@
+/* A minimal fake DOM for testing the bundled browser assets.
+ *
+ * It implements just enough of `window` and `document` to evaluate the scripts
+ * in `assets/` unchanged and to drive their event handlers, so that the tests
+ * in `test_assets.js` exercise the shipped files instead of a copy of their
+ * logic. Everything here is a stub: nothing is laid out, and only the event
+ * types that the scripts listen for are dispatched.
+ */
+"use strict";
+
+const fs = require("fs");
+const path = require("path");
+const vm = require("vm");
+
+const ASSETS = path.join(__dirname, "..", "..", "assets");
+
+// An element. `props` may set `id`, `href` (from which `hash` is derived, as
+// in a browser), and `children`.
+function element(tag, props) {
+  props = props || {};
+  const e = {
+    tagName: tag.toUpperCase(),
+    id: props.id || "",
+    parentNode: null,
+    childNodes: [],
+    style: {},
+    offsetWidth: 100,
+    offsetHeight: 50,
+    handlers: {},
+    classes: [],
+    attributes: {},
+  };
+  e.href = props.href || "";
+  // As in a browser, where an empty fragment gives an empty `hash`: this is
+  // what distinguishes a citation from Documenter's `href="#"` controls
+  const fragment = e.href.indexOf("#");
+  e.hash = fragment === -1 || fragment === e.href.length - 1 ? "" : e.href.slice(fragment);
+  e.classList = {
+    add: (c) => {
+      if (!e.classes.includes(c)) e.classes.push(c);
+    },
+    remove: (c) => {
+      e.classes = e.classes.filter((x) => x !== c);
+    },
+    contains: (c) => e.classes.includes(c),
+  };
+  e.setAttribute = (name, value) => {
+    e.attributes[name] = value;
+  };
+  e.removeAttribute = (name) => {
+    delete e.attributes[name];
+  };
+  e.getAttribute = (name) => (name in e.attributes ? e.attributes[name] : null);
+  e.addEventListener = (type, fn) => {
+    (e.handlers[type] = e.handlers[type] || []).push(fn);
+  };
+  e.appendChild = (child) => {
+    child.parentNode = e;
+    e.childNodes.push(child);
+    return child;
+  };
+  e.getBoundingClientRect = () => ({ top: 10, bottom: 30, left: 10, right: 60 });
+  e.querySelectorAll = () => [];
+  e.fire = (type, event) => {
+    (e.handlers[type] || []).forEach((fn) =>
+      fn(Object.assign({ currentTarget: e, target: e }, event))
+    );
+  };
+  (props.children || []).forEach((child) => e.appendChild(child));
+  return e;
+}
+
+// A page. `backlinks` are the elements returned for the selector that
+// `citations-backlinks.js` uses, `links` those in `document.links`, which is
+// what `citations-hover.js` walks.
+function page(options) {
+  options = options || {};
+  const store = {};
+  const window = {
+    innerWidth: 1000,
+    innerHeight: 800,
+    scrollX: 0,
+    scrollY: 0,
+    location: { hash: options.hash || "" },
+    sessionStorage: {
+      getItem: (key) => (key in store ? store[key] : null),
+      setItem: (key, value) => {
+        store[key] = String(value);
+      },
+    },
+    handlers: {},
+    addEventListener: (type, fn) => {
+      (window.handlers[type] = window.handlers[type] || []).push(fn);
+    },
+    fire: (type, event) => {
+      (window.handlers[type] || []).forEach((fn) => fn(event || {}));
+    },
+  };
+  const document = {
+    readyState: "complete",
+    body: element("body"),
+    links: options.links || [],
+    currentScript: { src: options.scriptSrc || "" },
+    handlers: {},
+    addEventListener: (type, fn) => {
+      (document.handlers[type] = document.handlers[type] || []).push(fn);
+    },
+    fire: (type, event) => {
+      (document.handlers[type] || []).forEach((fn) => fn(event || {}));
+    },
+    createElement: (tag) => element(tag),
+    querySelectorAll: (selector) => {
+      if (selector === ".citation-backlinks a") return options.backlinks || [];
+      return [];
+    },
+  };
+  if (options.hoverData) window.DocumenterCitationsHoverData = options.hoverData;
+  return { window, document, storage: store };
+}
+
+// Evaluate one of the bundled assets in the given page, as a browser would
+function load(filename, page) {
+  const source = fs.readFileSync(path.join(ASSETS, filename), "utf8");
+  const sandbox = {
+    window: page.window,
+    document: page.document,
+    URL: URL,
+    console: console,
+    setTimeout: setTimeout,
+    clearTimeout: clearTimeout,
+  };
+  vm.runInNewContext(source, vm.createContext(sandbox), { filename: filename });
+  return page;
+}
+
+module.exports = { element, page, load };

--- a/test/js/test_assets.js
+++ b/test/js/test_assets.js
@@ -1,0 +1,183 @@
+/* Tests for the bundled browser assets, run by `test/test_js_assets.jl`.
+ *
+ * Run directly with
+ *
+ *     node test/js/test_assets.js
+ *
+ * The scripts are evaluated against the fake DOM in `dom.js`. These tests
+ * cover the decisions the scripts make about which link the reader followed;
+ * the appearance of the popups and of the marked backlink is not testable
+ * here, and was checked in a browser.
+ */
+"use strict";
+
+const assert = require("assert");
+const { element, page, load } = require("./dom.js");
+
+const CLASS = "is-current-citation";
+const STORAGE_KEY = "documentercitations-followed-citation";
+
+const tests = [];
+function test(name, fn) {
+  tests.push([name, fn]);
+}
+
+// A bibliography page with one entry that is cited twice. As in the rendered
+// HTML, the backlinks sit in a `span` inside the `div` carrying the anchor of
+// the entry, and point to the citations on another page.
+function bibliographyPage(options) {
+  options = options || {};
+  const backlinks = [
+    element("a", { href: "../index.html#GoerzQ2022-cite-1" }),
+    element("a", { href: "../index.html#GoerzQ2022-cite-2" }),
+  ];
+  const entry = element("div", {
+    id: "GoerzQ2022",
+    children: [element("span", { children: backlinks })],
+  });
+  const p = page({ hash: options.hash, backlinks: backlinks });
+  if (options.followed) p.storage[STORAGE_KEY] = options.followed;
+  return Object.assign(p, { backlinks: backlinks, entry: entry });
+}
+
+function marked(p) {
+  return p.backlinks.map((a) => a.classList.contains(CLASS));
+}
+
+
+test("the backlink for the followed citation is marked", () => {
+  // The reader clicked the second citation, which led to the entry
+  const p = bibliographyPage({ followed: "GoerzQ2022-cite-2", hash: "#GoerzQ2022" });
+  load("citations-backlinks.js", p);
+  assert.deepStrictEqual(marked(p), [false, true]);
+});
+
+
+test("no backlink is marked when the bibliography is opened from the sidebar", () => {
+  // Same session, but this time the reader did not arrive at the entry: the
+  // citation followed earlier must not leave a mark (Documenter has no page
+  // load between pages, so the id is still in `sessionStorage`)
+  const p = bibliographyPage({ followed: "GoerzQ2022-cite-2", hash: "" });
+  load("citations-backlinks.js", p);
+  assert.deepStrictEqual(marked(p), [false, false]);
+});
+
+
+test("no backlink is marked when arriving at a section of the bibliography", () => {
+  const p = bibliographyPage({
+    followed: "GoerzQ2022-cite-2",
+    hash: "#Cited-References",
+  });
+  load("citations-backlinks.js", p);
+  assert.deepStrictEqual(marked(p), [false, false]);
+});
+
+
+test("the mark survives a click on one of Documenter's own controls", () => {
+  // The settings button and the sidebar toggle are `<a>` elements with an
+  // `id`, but they are not citations: clicking one must neither be remembered
+  // nor unmark the backlink of the citation the reader actually followed
+  const p = bibliographyPage({ followed: "GoerzQ2022-cite-1", hash: "#GoerzQ2022" });
+  load("citations-backlinks.js", p);
+  assert.deepStrictEqual(marked(p), [true, false]);
+  const gear = element("a", { id: "documenter-settings-button", href: "#" });
+  p.document.fire("click", { target: gear });
+  assert.strictEqual(p.storage[STORAGE_KEY], "GoerzQ2022-cite-1");
+  assert.deepStrictEqual(marked(p), [true, false]);
+});
+
+
+test("clicking a citation is remembered", () => {
+  const p = bibliographyPage({ hash: "" });
+  load("citations-backlinks.js", p);
+  const citation = element("a", {
+    id: "GoerzQ2022-cite-2",
+    href: "references/index.html#GoerzQ2022",
+  });
+  // The click is on the text inside the link, as it would be in a browser
+  p.document.fire("click", { target: element("em", { children: [] }) });
+  assert.strictEqual(p.storage[STORAGE_KEY], undefined);
+  p.document.fire("click", { target: citation });
+  assert.strictEqual(p.storage[STORAGE_KEY], "GoerzQ2022-cite-2");
+  // With the bibliography on the same page, there is no load to pick it up
+  assert.deepStrictEqual(marked(p), [false, true]);
+});
+
+
+// A page with a citation link, for the hover popups. Both the data and the
+// link point at the bibliography page, which is what gives the link a popup.
+function citationPage(hash) {
+  const link = element("a", {
+    id: "GoerzQ2022-cite-1",
+    href: "https://example.org/docs/references/index.html#GoerzQ2022",
+  });
+  const p = page({
+    hash: hash || "",
+    links: [link],
+    scriptSrc:
+      "https://example.org/docs/assets/documentercitations/citations-hover.js",
+    hoverData: {
+      GoerzQ2022: { html: "<p>M. H. Goerz et al.</p>", page: "references/index.html" },
+    },
+  });
+  load("citations-hover.js", p);
+  return Object.assign(p, { link: link });
+}
+
+function popupShown(p) {
+  return p.link.getAttribute("aria-describedby") !== null;
+}
+
+// Following a backlink to a citation focuses it. The browser updates the hash
+// before that focus and fires `hashchange` only afterwards, which is the order
+// used here.
+function jumpTo(p, id) {
+  p.window.location.hash = "#" + id;
+  p.link.fire("focus");
+  p.window.fire("hashchange");
+}
+
+
+test("the popup is skipped for the focus that follows a jump", () => {
+  const p = citationPage();
+  jumpTo(p, "GoerzQ2022-cite-1");
+  assert.ok(!popupShown(p), "a backlink must not open the popup of its own entry");
+});
+
+
+test("tabbing back to the citation still shows the popup", () => {
+  // Only the focus caused by the jump is skipped. The `hashchange` that the
+  // jump itself fires must not reset that, or the next focus is skipped too.
+  const p = citationPage();
+  jumpTo(p, "GoerzQ2022-cite-1");
+  p.link.fire("blur");
+  p.link.fire("focus");
+  assert.ok(popupShown(p), "the popup must be shown when focusing the link again");
+});
+
+
+test("returning to the citation later counts as a jump again", () => {
+  const p = citationPage();
+  jumpTo(p, "GoerzQ2022-cite-1");
+  // The reader moves on to some other part of the page ...
+  p.window.location.hash = "#Some-Section";
+  p.window.fire("hashchange");
+  // ... and then follows the backlink to the same citation once more
+  jumpTo(p, "GoerzQ2022-cite-1");
+  assert.ok(!popupShown(p), "the second jump must skip the popup as well");
+});
+
+
+let failed = 0;
+tests.forEach(([name, fn]) => {
+  try {
+    fn();
+    console.log("PASS: " + name);
+  } catch (e) {
+    failed += 1;
+    console.log("FAIL: " + name);
+    console.log("      " + (e && e.message ? e.message.split("\n").join("\n      ") : e));
+  }
+});
+console.log(`${tests.length - failed} of ${tests.length} tests passed`);
+process.exit(failed === 0 ? 0 : 1);

--- a/test/run_makedocs.jl
+++ b/test/run_makedocs.jl
@@ -3,6 +3,13 @@ using Documenter: Documenter, makedocs
 import Logging
 
 
+# Remove the `id` attributes that the `show_backlinks` feature puts on the
+# citation links, so that a test can check the rendered HTML of a citation
+# without depending on how often the reference is cited elsewhere. The
+# attributes themselves are covered in `test_backlinks.jl`.
+strip_cite_ids(html) = replace(html, r" id=\"[^\"]+-cite-[0-9]+\"" => "")
+
+
 # Run `makedocs` as part of a test.
 #
 # Use as:

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -80,6 +80,11 @@ using DocumenterCitations
         include("test_backlinks.jl")
     end
 
+    println("\n* bundled browser assets (test_js_assets.jl):")
+    @time @safetestset "js_assets" begin
+        include("test_js_assets.jl")
+    end
+
     println("\n* integration test (test_integration.jl):")
     @time @safetestset "integration" begin
         include("test_integration.jl")

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -75,6 +75,11 @@ using DocumenterCitations
         include("test_show_hover.jl")
     end
 
+    println("\n* backlinks (test_backlinks.jl):")
+    @time @safetestset "backlinks" begin
+        include("test_backlinks.jl")
+    end
+
     println("\n* integration test (test_integration.jl):")
     @time @safetestset "integration" begin
         include("test_integration.jl")

--- a/test/test_anchor_keys.jl
+++ b/test/test_anchor_keys.jl
@@ -83,7 +83,7 @@ end
         @test contains(output, "normalizes to ambiguous \"Chirikjian_2012\"")
 
         #! format: off
-        index_html = read(joinpath(dir, "build", "index.html"), String)
+        index_html = strip_cite_ids(read(joinpath(dir, "build", "index.html"), String))
         @test contains(index_html, "<a href=\"references/#Chirikjian_2012\">")
         @test contains(index_html, "<a href=\"references/#Chirikjian_2012-2\">")
 

--- a/test/test_assets.jl
+++ b/test/test_assets.jl
@@ -105,11 +105,13 @@ end
 
 @testset "insert_css=false" begin
 
-    # `show_hover=false` as well, so that no other asset is inserted either
+    # `show_hover` and `show_backlinks` are off as well, so that no other asset
+    # is inserted either
     bib = CitationBibliography(
         joinpath(@__DIR__, "test_assets", "src", "refs.bib");
         insert_css=false,
-        show_hover=false
+        show_hover=false,
+        show_backlinks=false
     )
 
     run_makedocs(
@@ -137,7 +139,8 @@ end
     bib = CitationBibliography(
         joinpath(@__DIR__, "test_assets", "src", "refs.bib");
         insert_css=false,
-        show_hover=false
+        show_hover=false,
+        show_backlinks=false
     )
 
     run_makedocs(

--- a/test/test_backlinks.jl
+++ b/test/test_backlinks.jl
@@ -1,0 +1,192 @@
+using DocumenterCitations
+using Documenter
+using Test
+
+include("run_makedocs.jl")
+
+
+const BIBFILE = joinpath(@__DIR__, "..", "docs", "src", "refs.bib")
+
+const PAGES =
+    ["Home" => "index.md", "Usage" => "usage.md", "References" => "references.md",]
+
+const BACKLINKS_JS = "citations-backlinks.js"
+
+# The tag that `Documenter` renders for the bundled script (relative to the
+# page, which is why the tests using it build with `prettyurls=false`)
+const BACKLINKS_JS_TAG = "<script src=\"assets/documentercitations/$BACKLINKS_JS\"></script>"
+
+
+@testset "backlinks (default)" begin
+
+    bib = CitationBibliography(BIBFILE)
+    @test bib.show_backlinks  # on by default
+
+    run_makedocs(
+        splitext(@__FILE__)[1];
+        sitename="Test",
+        plugins=[bib],
+        pages=PAGES,
+        format=Documenter.HTML(edit_link="master", repolink=" ", prettyurls=false),
+        check_success=true
+    ) do dir, result, success, backtrace, output
+
+        @test success
+
+        # The citations are numbered in the order in which they appear in the
+        # documentation, across pages. The `Example` docstring cites
+        # `GoerzQ2022` twice, and citations in a docstring are attributed to
+        # the docstring, not to any section inside it
+        @test [site.id for site in bib.backlinks["GoerzQ2022"]] == [
+            "GoerzQ2022-cite-1",
+            "GoerzQ2022-cite-2",
+            "GoerzQ2022-cite-3",
+            "GoerzQ2022-cite-4",
+        ]
+        @test [site.section for site in bib.backlinks["GoerzQ2022"]] == [
+            "Introduction",
+            "Details",
+            "DocumenterCitations.Example",
+            "DocumenterCitations.Example",
+        ]
+        @test [site.src for site in bib.backlinks["BrifNJP2010"]] == ["index.md", "usage.md"]
+        @test [site.section for site in bib.backlinks["BrifNJP2010"]] == ["Details", "Examples"]
+
+        index_html = read(joinpath(dir, "build", "index.html"), String)
+        # Every citation link carries the anchor that the backlinks point to
+        @test contains(index_html, "id=\"GoerzQ2022-cite-1\"")
+        @test contains(index_html, "id=\"GoerzQ2022-cite-2\"")
+        @test contains(index_html, "id=\"BrifNJP2010-cite-1\"")
+        # … including the citations inside docstrings
+        @test contains(index_html, "id=\"GoerzQ2022-cite-3\"")
+        @test !contains(index_html, "citation-backlinks")
+
+        references_html = read(joinpath(dir, "build", "references.html"), String)
+        @test contains(references_html, "<span class=\"citation-backlinks\">")
+        @test contains(
+            references_html,
+            "<a href=\"index.html#GoerzQ2022-cite-1\" title=\"Cited in Introduction\">↩<sup>1</sup></a>"
+        )
+        @test contains(
+            references_html,
+            "<a href=\"usage.html#BrifNJP2010-cite-2\" title=\"Cited in Examples\">↩<sup>2</sup></a>"
+        )
+        # A non-canonical block does not get backlinks
+        @test count("citation-backlinks", references_html) == 2
+
+        # The script that marks the backlink for the citation that the reader
+        # followed is inserted automatically
+        @test isfile(joinpath(dir, "build", "assets", "documentercitations", BACKLINKS_JS))
+        @test contains(index_html, BACKLINKS_JS_TAG)
+
+    end
+
+end
+
+
+@testset "backlinks with prettyurls" begin
+
+    bib = CitationBibliography(BIBFILE)
+
+    run_makedocs(
+        splitext(@__FILE__)[1];
+        sitename="Test",
+        plugins=[bib],
+        pages=PAGES,
+        format=Documenter.HTML(edit_link="master", repolink=" "),
+        check_success=true
+    ) do dir, result, success, backtrace, output
+
+        @test success
+
+        references_html = read(joinpath(dir, "build", "references", "index.html"), String)
+        @test contains(references_html, "<a href=\"../#GoerzQ2022-cite-1\"")
+        @test contains(references_html, "<a href=\"../usage/#BrifNJP2010-cite-2\"")
+
+    end
+
+end
+
+
+@testset "show_backlinks=false" begin
+
+    bib = CitationBibliography(BIBFILE; show_backlinks=false)
+
+    run_makedocs(
+        splitext(@__FILE__)[1];
+        sitename="Test",
+        plugins=[bib],
+        pages=PAGES,
+        format=Documenter.HTML(edit_link="master", repolink=" ", prettyurls=false),
+        check_success=true
+    ) do dir, result, success, backtrace, output
+
+        @test success
+
+        @test isempty(bib.backlinks)
+
+        index_html = read(joinpath(dir, "build", "index.html"), String)
+        @test !contains(index_html, "-cite-1")
+
+        references_html = read(joinpath(dir, "build", "references.html"), String)
+        @test !contains(references_html, "citation-backlinks")
+
+        @test !isfile(joinpath(dir, "build", "assets", "documentercitations", BACKLINKS_JS))
+        @test !contains(index_html, BACKLINKS_JS_TAG)
+
+    end
+
+end
+
+
+@testset "backlinks are not part of the hover data" begin
+
+    bib = CitationBibliography(BIBFILE)
+
+    run_makedocs(
+        splitext(@__FILE__)[1];
+        sitename="Test",
+        plugins=[bib],
+        pages=PAGES,
+        format=Documenter.HTML(edit_link="master", repolink=" ", prettyurls=false),
+        check_success=true
+    ) do dir, result, success, backtrace, output
+
+        @test success
+
+        data_file =
+            joinpath(dir, "build", "assets", "documentercitations", "citations-data.js")
+        @test isfile(data_file)
+        @test !contains(read(data_file, String), "citation-backlinks")
+
+    end
+
+end
+
+
+@testset "backlinks do not affect the LaTeX output" begin
+
+    tex_files = Dict{String,String}()
+
+    for show_backlinks in (true, false)
+        bib = CitationBibliography(BIBFILE; show_backlinks=show_backlinks)
+        run_makedocs(
+            splitext(@__FILE__)[1];
+            sitename="Test",
+            plugins=[bib],
+            pages=PAGES,
+            format=Documenter.LaTeX(platform="none"),
+            check_success=true
+        ) do dir, result, success, backtrace, output
+            @test success
+            tex_file = joinpath(dir, "build", "Test.tex")
+            @test isfile(tex_file)
+            tex_files["$show_backlinks"] = read(tex_file, String)
+            @test !isdir(joinpath(dir, "build", "assets", "documentercitations"))
+        end
+    end
+
+    @test tex_files["true"] == tex_files["false"]
+    @test !contains(tex_files["true"], "cite-1")
+
+end

--- a/test/test_backlinks.jl
+++ b/test/test_backlinks.jl
@@ -164,6 +164,41 @@ end
 end
 
 
+@testset "citations in a heading" begin
+
+    # A citation inside a heading belongs to the section that the heading
+    # opens, not to the preceding one, and the title of that section must not
+    # contain the rendered form of that citation
+
+    bib = CitationBibliography(BIBFILE)
+
+    run_makedocs(
+        joinpath(@__DIR__, "test_backlinks_headings");
+        sitename="Test",
+        plugins=[bib],
+        pages=["Home" => "index.md", "References" => "references.md"],
+        format=Documenter.HTML(edit_link="master", repolink=" ", prettyurls=false),
+        check_success=true
+    ) do dir, result, success, backtrace, output
+
+        @test success
+
+        section = "A section citing BrifNJP2010"
+        @test [site.section for site in bib.backlinks["BrifNJP2010"]] == [section]
+        @test [site.section for site in bib.backlinks["GoerzQ2022"]] == ["Introduction", section]
+
+        references_html = read(joinpath(dir, "build", "references.html"), String)
+        @test contains(references_html, "title=\"Cited in $section\">↩<sup>1</sup></a>")
+        @test contains(references_html, "title=\"Cited in $section\">↩<sup>2</sup></a>")
+        # The section title is taken before the citations in the heading are
+        # expanded, so it cannot pick up a citation label like "[1]"
+        @test !contains(references_html, "title=\"Cited in A section citing [")
+
+    end
+
+end
+
+
 @testset "backlinks do not affect the LaTeX output" begin
 
     tex_files = Dict{String,String}()

--- a/test/test_backlinks/src/index.md
+++ b/test/test_backlinks/src/index.md
@@ -1,0 +1,14 @@
+# Testing backlinks from the bibliography to the citations
+
+## Introduction
+
+A first citation of Ref. [GoerzQ2022](@cite).
+
+## Details
+
+The same reference is cited again in [GoerzQ2022](@citet), and a second
+reference is cited in Ref. [BrifNJP2010](@cite).
+
+```@docs
+DocumenterCitations.Example
+```

--- a/test/test_backlinks/src/references.md
+++ b/test/test_backlinks/src/references.md
@@ -1,0 +1,11 @@
+# References
+
+```@bibliography
+```
+
+## Non-canonical references
+
+```@bibliography
+Canonical = false
+GoerzQ2022
+```

--- a/test/test_backlinks/src/usage.md
+++ b/test/test_backlinks/src/usage.md
@@ -1,0 +1,5 @@
+# Usage
+
+## Examples
+
+A citation of Ref. [BrifNJP2010](@cite) on a second page.

--- a/test/test_backlinks_headings/src/index.md
+++ b/test/test_backlinks_headings/src/index.md
@@ -1,0 +1,10 @@
+# Testing citations in headings
+
+## Introduction
+
+A first citation of Ref. [GoerzQ2022](@cite).
+
+## A section citing [BrifNJP2010](@cite)
+
+The same reference is cited again in [GoerzQ2022](@citet), in a section whose
+heading carries a citation of its own.

--- a/test/test_backlinks_headings/src/references.md
+++ b/test/test_backlinks_headings/src/references.md
@@ -1,0 +1,4 @@
+# References
+
+```@bibliography
+```

--- a/test/test_bibliography_block_pages.jl
+++ b/test/test_bibliography_block_pages.jl
@@ -70,7 +70,8 @@ end
         #! format: on
 
         build(paths...) = joinpath(dir, "build", paths...)
-        citation(n) = Regex("\\[<a href=\"[^\"]+\">$n</a>\\]")
+        # the `[^>]*` skips the `id` attribute added for the backlinks
+        citation(n) = Regex("\\[<a href=\"[^\"]+\"[^>]*>$n</a>\\]")
         contentlink(name) = ".html#$(replace(name, " " => "-"))\">$name"
 
         index_html = FileContent(build("index.html"))

--- a/test/test_collect_from_docstrings.jl
+++ b/test/test_collect_from_docstrings.jl
@@ -24,7 +24,7 @@ include("run_makedocs.jl")
 
         index_outfile = joinpath(dir, "build", "index.html")
         @test isfile(index_outfile)
-        html = read(index_outfile, String)
+        html = strip_cite_ids(read(index_outfile, String))
         nbsp = "\u00A0"  # non-breaking space
         @test occursin("citing Ref.$(nbsp)[<a href=\"references/#GoerzQ2022\">1</a>]", html)
 

--- a/test/test_integration.jl
+++ b/test/test_integration.jl
@@ -86,24 +86,28 @@ end
     style = :alpha
     insert_css = true
     show_hover = true
+    show_backlinks = true
     entries = Bibliography.import_bibtex(bibfile)
     citations = OrderedDict{String,Int64}()
     page_citations = Dict{String,Set{String}}()
     anchor_map = Documenter.AnchorMap()
     anchor_keys = Bijections.Bijection{String,String}()
     hover_entries = Dict{String,Tuple{String,String}}()
+    backlinks = Dict{String,Vector{DocumenterCitations.CitationSite}}()
 
     bib = CitationBibliography(
         bibfile,
         style,
         insert_css,
         show_hover,
+        show_backlinks,
         entries,
         citations,
         page_citations,
         anchor_map,
         anchor_keys,
-        hover_entries
+        hover_entries,
+        backlinks
     )
 
     links = InterLinks(
@@ -135,7 +139,8 @@ end
         @test !contains(references_html, "<div id=\"Wilhelm2003\">")  # pre-#95
         @test contains(references_html, "<div id=\"Wilhelm2003_10132\">")
 
-        syntax_html = read(joinpath(dir, "build", "syntax", "index.html"), String)
+        syntax_html =
+            strip_cite_ids(read(joinpath(dir, "build", "syntax", "index.html"), String))
         @test contains(syntax_html, "<a href=\"../references/#Wilhelm2003_10132\">")
 
     end

--- a/test/test_js_assets.jl
+++ b/test/test_js_assets.jl
@@ -1,0 +1,29 @@
+using Test
+
+# The behavior of the bundled browser assets is tested in JavaScript, in
+# `test/js/test_assets.js`, which evaluates the scripts in `assets/` against a
+# minimal fake DOM. This runs those tests with `node`, which is available on
+# the CI runners. Without it, they are skipped: the package itself does not
+# depend on any JavaScript tooling.
+
+const NODE = Sys.which("node")
+
+const TEST_SCRIPT = joinpath(@__DIR__, "js", "test_assets.js")
+
+@testset "bundled browser assets" begin
+
+    if isnothing(NODE)
+        @warn "Skipping the tests for the bundled browser assets: `node` not found"
+        @test_skip isnothing(NODE)
+    else
+        io = IOBuffer()
+        cmd = pipeline(ignorestatus(`$NODE $TEST_SCRIPT`); stdout=io, stderr=io)
+        exitcode = run(cmd).exitcode
+        output = String(take!(io))
+        if exitcode ≠ 0
+            println(output)
+        end
+        @test exitcode == 0
+    end
+
+end

--- a/test/test_keys_with_underscores.jl
+++ b/test/test_keys_with_underscores.jl
@@ -25,7 +25,7 @@ include("run_makedocs.jl")
         @test success
 
         #! format: off
-        index_html = read(joinpath(dir, "build", "index.html"), String)
+        index_html = strip_cite_ids(read(joinpath(dir, "build", "index.html"), String))
         @test contains(index_html, "[<a href=\"references/#rabiner_tutorial_1989\">1</a>]")
         @test contains(index_html, "[<a href=\"references/#GoerzQ2022\">2</a>, with <em>emphasis</em>]")
 
@@ -73,7 +73,7 @@ end
         @test success
 
         #! format: off
-        index_html = read(joinpath(dir, "build", "index.html"), String)
+        index_html = strip_cite_ids(read(joinpath(dir, "build", "index.html"), String))
         @test contains(index_html, "[<a href=\"references/#rabiner_tutorial_1989\">1</a>]")
         @test contains(index_html, "[<a href=\"references/#Goerz_Q_2022\">2</a>]")
         @test !contains(index_html, "*")  # everything was normalized to "_"

--- a/test/test_show_hover.jl
+++ b/test/test_show_hover.jl
@@ -197,7 +197,7 @@ end
 
         @test success
 
-        index_html = read(joinpath(dir, "build", "index.html"), String)
+        index_html = strip_cite_ids(read(joinpath(dir, "build", "index.html"), String))
         @test contains(index_html, "<a href=\"index.html#GoerzQ2022\">")
 
         data_file =

--- a/test/test_undefined_citations.jl
+++ b/test/test_undefined_citations.jl
@@ -32,7 +32,7 @@ include("run_makedocs.jl")
         @test isfile(index_html_file)
         if isfile(index_html_file)
             #! format: off
-            index_html = read(index_html_file, String)
+            index_html = strip_cite_ids(read(index_html_file, String))
             @test occursin("and a non-existing key [?]", index_html)
             @test occursin("[?, ?, ?, <a href=\"references/#BrumerShapiro2003\">2</a>–<a href=\"references/#KochEPJQT2022\">6</a>, and references therein]", index_html)
             @test occursin("<a href=\"references/#BrumerShapiro2003\">Brumer and Shapiro [2]</a>, <a href=\"references/#BrifNJP2010\">Brif <em>et al.</em> [3]</a>, [?], [?], <a href=\"references/#SolaAAMOP2018\">Sola <em>et al.</em> [4]</a>, [?], <a href=\"references/#Wilhelm2003_10132\">Wilhelm <em>et al.</em> [5]</a>, <a href=\"references/#KochEPJQT2022\">Koch <em>et al.</em> [6]</a>, and references therein", index_html)
@@ -89,7 +89,7 @@ end
         @test isfile(index_html_file)
         if isfile(index_html_file)
            #! format: off
-           index_html = read(index_html_file, String)
+           index_html = strip_cite_ids(read(index_html_file, String))
            @test occursin("and a non-existing key [?]", index_html)
            @test occursin("[?], [?], <a href=\"references/#SolaAAMOP2018\">Sola <em>et al.</em> [SCMM18]</a>, [?], <a href=\"references/#Wilhelm2003_10132\">Wilhelm <em>et al.</em> [WKM+20]</a>, <a href=\"references/#KochEPJQT2022\">Koch <em>et al.</em> [KBC+22]</a>, and references therein", index_html)
            @test occursin("<a href=\"references/#BrumerShapiro2003\">Brumer and Shapiro [BS03]</a>, <a href=\"references/#BrifNJP2010\">Brif <em>et al.</em> [BCR10]</a>, [?], [?], <a href=\"references/#SolaAAMOP2018\">Sola <em>et al.</em> [SCMM18]</a>, [?], <a href=\"references/#Wilhelm2003_10132\">Wilhelm <em>et al.</em> [WKM+20]</a>, <a href=\"references/#KochEPJQT2022\">Koch <em>et al.</em> [KBC+22]</a>, and references therein", index_html)
@@ -123,7 +123,7 @@ end
         @test isfile(index_html_file)
         if isfile(index_html_file)
            #! format: off
-           index_html = read(index_html_file, String)
+           index_html = strip_cite_ids(read(index_html_file, String))
            @test occursin("and a non-existing key (???)", index_html)
            @test occursin("(<a href=\"references/#BrumerShapiro2003\">Brumer and Shapiro, 2003</a>; <a href=\"references/#BrifNJP2010\">Brif <em>et al.</em>, 2010</a>; ???; ???; <a href=\"references/#SolaAAMOP2018\">Sola <em>et al.</em>, 2018</a>; ???; <a href=\"references/#Wilhelm2003_10132\">Wilhelm <em>et al.</em>, 2020</a>; <a href=\"references/#KochEPJQT2022\">Koch <em>et al.</em>, 2022</a>; and references therein)", index_html)
            @test occursin("<a href=\"references/#BrumerShapiro2003\">Brumer and Shapiro (2003)</a>, <a href=\"references/#BrifNJP2010\">Brif <em>et al.</em> (2010)</a>, ???, ???, <a href=\"references/#SolaAAMOP2018\">Sola <em>et al.</em> (2018)</a>, ???, <a href=\"references/#Wilhelm2003_10132\">Wilhelm <em>et al.</em> (2020)</a>, <a href=\"references/#KochEPJQT2022\">Koch <em>et al.</em> (2022)</a>, and references therein", index_html)


### PR DESCRIPTION
Each entry in a canonical `@bibliography` block in the HTML documentation now ends with a list of backlinks (`↩`) to the places where the reference is cited, in the order in which the citations appear in the documentation. Hovering over a backlink names the section it points to. This is the counterpart of the hover popups from #119: the popups take the reader from a citation to the entry without leaving the page, the backlinks take them from the entry to every place that cites it.

The feature is on by default. It can be switched off with

```julia
bib = CitationBibliography("refs.bib"; show_backlinks=false)
```

After following a citation, the backlink that leads back to it is marked with an outline, so that the reader can see where they came from. That matters for a reference that is cited often: in this package's own documentation, one entry carries 47 backlinks.

## Implementation

* A new `CitationSiteNode` element wraps the link of every expanded citation and gives it an `id` attribute during HTML rendering, so that a backlink jumps to the exact citation, not just to the enclosing section. The wrapped link stays a regular `MarkdownAST.Link` in the page tree, so `Documenter` still resolves it and handles `prettyurls`.

* `ExpandCitations` assigns those anchor names and records the citation sites (source file, anchor, section title) in the new `backlinks` attribute of the plugin. It now walks the pages in navigation order, as `CollectCitations` does, so that the backlinks of a reference follow the order of the documentation. Citations inside a docstring are attributed to the docstring, not to a section inside it.

* The backlinks themselves are built in `domify_bib`, after the entry has been captured for the hover popups, so that a popup shows the entry without them. They are appended only for canonical blocks, which are the only ones that define link targets.

* The mark for the followed citation is handled by the new bundled `citations-backlinks.js`, copied and registered by the existing `InjectAssets` step whenever `show_backlinks` is set. The id of the followed citation is remembered in `sessionStorage` (the bibliography is usually on another page, which rules out passing it in a variable), and the matching backlink is given the class `is-current-citation`, outlined by `citations.css`. Without JavaScript, or when the reader reaches the bibliography by other means, the backlinks are all shown alike.

* `citations-hover.js` no longer opens a popup for the focus that follows a jump to a citation. Jumping to a citation focuses it, and any focus used to show the popup, so a reader clicking a backlink was shown the entry they had just come from. The link being the current fragment target identifies that focus (the hash is already up to date when the focus event fires; `hashchange` only comes afterwards). Only that first focus is skipped, so tabbing back to the link still describes it.

`CitationSiteNode` renders as its bare content in every output format other than HTML, so the LaTeX output is unchanged whether the feature is on or off.

## Testing

The new `test/test_backlinks.jl` covers the recorded citation sites and their order across pages and docstrings, the rendered backlinks and their `title` attributes, `prettyurls` on and off, the absence of backlinks in non-canonical blocks, the `show_backlinks=false` opt-out (no anchors, no backlinks, no script), and the fact that the hover data does not contain them. It also builds the same documentation with the feature on and off in the LaTeX writer and asserts that the two `.tex` files are byte-identical.

`test/run_makedocs.jl` gains a `strip_cite_ids` helper so that existing tests can check the rendered HTML of a citation without depending on how often the reference is cited elsewhere.

Beyond the test suite, I checked the built documentation in a browser: following a citation and coming back through the marked backlink, in the light and dark themes, with the keyboard, and for an entry with dozens of backlinks (they wrap onto the next line).

Closes #69.
