### PR TITLE
Allow combining multiple bib files (unofficially)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * A warning if any of the `assets` of `Documenter.HTML` is an unmodified copy of a `citations.css` bundled with some version of `DocumenterCitations`. Such a copy is redundant, as the stylesheet is now inserted automatically, and it would mask any future update of the bundled stylesheet. Customized stylesheets do not trigger the warning. [[#116][]]
 * Hovering over a citation link in the HTML documentation now shows the corresponding bibliography entry in a popup, similar to the footnote previews in `Documenter`. This is enabled by default; instantiate the plugin with `show_hover=false` to disable it. [[#67][], [#119][]]
 * Each entry in a canonical `@bibliography` block in the HTML documentation now ends with backlinks (`↩`) to the places where the reference is cited. After following a citation, the backlink that leads back to it is marked. This is enabled by default; instantiate the plugin with `show_backlinks=false` to disable it. [[#69][], [#120][]]
+* An unofficial and unsupported hook that allows seeding the plugin from multiple `.bib` files. See `test/test_multiple_bibfiles.jl` for a worked example. [[#72][], [#121][]]
 
 
 ### Changed
@@ -239,6 +240,7 @@ There were several bugs and limitations in version `1.2.x` for which some existi
 [1.2.0]: https://github.com/JuliaDocs/DocumenterCitations.jl/compare/v1.1.0...v1.2.0
 [1.1.0]: https://github.com/JuliaDocs/DocumenterCitations.jl/compare/v1.0.0...v1.1.0
 [1.0.0]: https://github.com/JuliaDocs/DocumenterCitations.jl/compare/v0.2.12...v1.0.0
+[#121]: https://github.com/JuliaDocs/DocumenterCitations.jl/pull/121
 [#120]: https://github.com/JuliaDocs/DocumenterCitations.jl/pull/120
 [#119]: https://github.com/JuliaDocs/DocumenterCitations.jl/pull/119
 [#117]: https://github.com/JuliaDocs/DocumenterCitations.jl/pull/117
@@ -257,6 +259,7 @@ There were several bugs and limitations in version `1.2.x` for which some existi
 [#78]: https://github.com/JuliaDocs/DocumenterCitations.jl/issues/78
 [#74]: https://github.com/JuliaDocs/DocumenterCitations.jl/pull/74
 [#73]: https://github.com/JuliaDocs/DocumenterCitations.jl/issues/73
+[#72]: https://github.com/JuliaDocs/DocumenterCitations.jl/issues/72
 [#70]: https://github.com/JuliaDocs/DocumenterCitations.jl/pull/70
 [#69]: https://github.com/JuliaDocs/DocumenterCitations.jl/issues/69
 [#67]: https://github.com/JuliaDocs/DocumenterCitations.jl/issues/67

--- a/src/DocumenterCitations.jl
+++ b/src/DocumenterCitations.jl
@@ -128,12 +128,28 @@ struct CitationBibliography <: Documenter.Plugin
 
 end
 
+# Read the entries from `bibfile`. This is the default for the `_entries`
+# keyword argument of `CitationBibliography`, so that `bibfile` is checked for
+# existence only if it is actually read.
+function _read_bibfile(bibfile)
+    if (length(bibfile) > 0) && !isfile(bibfile)
+        error("bibfile $(repr(bibfile)) does not exist")
+    end
+    return Bibliography.import_bibtex(bibfile)
+end
+
+
 function CitationBibliography(
     bibfile::AbstractString="";
     style=nothing,
     insert_css=true,
     show_hover=true,
-    show_backlinks=true
+    show_backlinks=true,
+    _entries=_read_bibfile(bibfile),
+    # `_entries` is deliberate undocumented, intended to give people a "hack"
+    # into enabling the unsupported use of multiple bib files,
+    # https://github.com/JuliaDocs/DocumenterCitations.jl/issues/72. If given,
+    # `bibfile` is not read and serves only as a label in log messages.
 )
     if isnothing(style)
         style = :numeric
@@ -142,9 +158,8 @@ function CitationBibliography(
         @debug "Auto-upgrading :alpha to AlphaStyle()"
         style = AlphaStyle()
     end
-    bibfile_entries = Bibliography.import_bibtex(bibfile)
-    entries = OrderedDict{String,eltype(values(bibfile_entries))}()
-    for (bibfile_key, entry) in bibfile_entries
+    entries = OrderedDict{String,eltype(values(_entries))}()
+    for (bibfile_key, entry) in _entries
         # The `text` in `[text](@cite)` has to be unambiguous when
         # round-tripping between String and MarkdownAST.Node. Since `_` and `*`
         # can both indicate emphasis in markdown, we normalize to `_` (which
@@ -166,13 +181,8 @@ function CitationBibliography(
         # `makedocs`, and then `Documenter.getplugin` instantiated a new object
         # with the default (empty) constructor
         @warn "No `bibfile`. Did you instantiate `bib = CitationBibliography(bibfile)` and pass `bib` to `makedocs` as an element of the `plugins` keyword argument?"
-    else
-        if !isfile(bibfile)
-            error("bibfile $(repr(bibfile)) does not exist")
-        end
-        if length(entries) == 0
-            @warn "No entries loaded from $(repr(bibfile))"
-        end
+    elseif length(entries) == 0
+        @warn "No entries loaded from $(repr(bibfile))"
     end
     citations = OrderedDict{String,Int64}()
     page_citations = Dict{String,Set{String}}()

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -60,6 +60,11 @@ using DocumenterCitations
         include("test_keys_with_underscores.jl")
     end
 
+    println("\n* multiple_bibfiles (test_multiple_bibfiles.jl):")
+    @time @safetestset "multiple_bibfiles" begin
+        include("test_multiple_bibfiles.jl")
+    end
+
     println("\n* anchor_keys (test_anchor_keys.jl):")
     @time @safetestset "anchor_keys" begin
         include("test_anchor_keys.jl")

--- a/test/test_multiple_bibfiles.jl
+++ b/test/test_multiple_bibfiles.jl
@@ -1,0 +1,81 @@
+using DocumenterCitations
+using Bibliography
+using Test
+
+include("run_makedocs.jl")
+
+# How to use more than one `.bib` file
+# (https://github.com/JuliaDocs/DocumenterCitations.jl/issues/72)
+#
+# `CitationBibliography` reads a single `bibfile`. Multiple files can be
+# combined by reading them manually and passing the merged entries to the
+# private `_entries` keyword argument. This is not officially supported: the
+# `_entries` argument is deliberately undocumented.
+#
+# Multiple bib files are officially unsupported, but this test is a commitment
+# to allow the hack / workaround in future non-breaking releases.
+
+@testset "multiple bib files" begin
+
+    bibfiles = [
+        joinpath(@__DIR__, "test_multiple_bibfiles", "src", "refs_reviews.bib"),
+        joinpath(@__DIR__, "test_multiple_bibfiles", "src", "refs_books.bib"),
+    ]
+
+    # `Bibliography.import_bibtex` returns an `OrderedDict` of citation keys to
+    # entries, which is exactly what `_entries` expects. Merging preserves the
+    # order in which the files are listed. For a key that occurs in more than
+    # one file, the entry from the *last* file wins.
+    entries = merge(Bibliography.import_bibtex.(bibfiles)...)
+    @test collect(keys(entries)) ==
+          ["BrifNJP2010", "KochJPCM2016", "Tannor2007", "BrumerShapiro2003"]
+
+    # Since `_entries` is given, the `bibfile` argument is not read, and it does
+    # not have to exist as a file. It is used only as a label in the error
+    # messages for citation keys that are not found ("Key … not found in entries
+    # from …"), so any string that identifies the source of the entries will do.
+    bib = CitationBibliography(
+        join(basename.(bibfiles), ", ");
+        style=:numeric,
+        _entries=entries
+    )
+    @test bib.bibfile == "refs_reviews.bib, refs_books.bib"
+    @test collect(keys(bib.entries)) == collect(keys(entries))
+
+    # From here on, `bib` is an ordinary plugin object: pass it to `makedocs` as
+    # an element of the `plugins` keyword argument, as usual.
+    run_makedocs(
+        joinpath(@__DIR__, "test_multiple_bibfiles");
+        sitename="Test",
+        plugins=[bib],
+        pages=["Home" => "index.md", "References" => "references.md",],
+        check_success=true
+    ) do dir, result, success, backtrace, output
+
+        @test success
+
+        # Citations from both files resolve, and the citation numbers follow the
+        # order of the citations in `index.md`, not the order of the entries in
+        # the merged dict.
+        #! format: off
+        index_html = strip_cite_ids(read(joinpath(dir, "build", "index.html"), String))
+        @test contains(index_html, "[<a href=\"references/#Tannor2007\">1</a>]")
+        @test contains(index_html, "[<a href=\"references/#BrifNJP2010\">2</a>]")
+        @test contains(index_html, "[<a href=\"references/#BrumerShapiro2003\">3</a>]")
+        @test contains(index_html, "[<a href=\"references/#KochJPCM2016\">4</a>]")
+
+        # All four entries end up in the single `@bibliography` block.
+        references_html = read(joinpath(dir, "build", "references", "index.html"), String)
+        @test contains(references_html, "<div id=\"Tannor2007\">")
+        @test contains(references_html, "<div id=\"BrifNJP2010\">")
+        @test contains(references_html, "<div id=\"BrumerShapiro2003\">")
+        @test contains(references_html, "<div id=\"KochJPCM2016\">")
+        #! format: on
+
+    end
+
+    # Without `_entries`, `bibfile` is read, and thus must exist.
+    exc = @test_throws ErrorException CitationBibliography("does_not_exist.bib")
+    @test contains(exc.value.msg, "bibfile \"does_not_exist.bib\" does not exist")
+
+end

--- a/test/test_multiple_bibfiles/src/index.md
+++ b/test/test_multiple_bibfiles/src/index.md
@@ -1,0 +1,7 @@
+# Multiple bib files
+
+The `CitationBibliography` object for this documentation was built from two `.bib` files, `refs_reviews.bib` and `refs_books.bib`.
+
+We cite an entry from the second file [Tannor2007](@cite), then one from the first file [BrifNJP2010](@cite), then the remaining entries of the second [BrumerShapiro2003](@cite) and the first file [KochJPCM2016](@cite).
+
+The citation numbers follow the order in which the citations appear in the documentation, irrespective of which file the entries came from.

--- a/test/test_multiple_bibfiles/src/references.md
+++ b/test/test_multiple_bibfiles/src/references.md
@@ -1,0 +1,4 @@
+# References
+
+```@bibliography
+```

--- a/test/test_multiple_bibfiles/src/refs_books.bib
+++ b/test/test_multiple_bibfiles/src/refs_books.bib
@@ -1,0 +1,15 @@
+@book{Tannor2007,
+    Address = {Sausalito, California},
+    Author = {Tannor, David J.},
+    Publisher = {University Science Books},
+    Title = {Introduction to Quantum Mechanics: A Time-Dependent Perspective},
+    Year = {2007},
+    Url = {https://uscibooks.aip.org/books/introduction-to-quantum-mechanics-a-time-dependent-perspective/},
+}
+
+@book{BrumerShapiro2003,
+    Author = {Brumer, P. and Shapiro, M.},
+    Publisher = {Wiley Interscience},
+    Title = {Principles and Applications of the Quantum Control of Molecular Processes},
+    Year = {2003},
+}

--- a/test/test_multiple_bibfiles/src/refs_reviews.bib
+++ b/test/test_multiple_bibfiles/src/refs_reviews.bib
@@ -1,0 +1,19 @@
+@article{BrifNJP2010,
+    Author = {Brif, Constantin and Chakrabarti, Raj and Rabitz, Herschel},
+    Title = {Control of quantum phenomena: past, present and future},
+    Journal = {New J. Phys.},
+    Year = {2010},
+    Doi = {10.1088/1367-2630/12/7/075008},
+    Pages = {075008},
+    Volume = {12},
+}
+
+@article{KochJPCM2016,
+    Author = {Koch, Christiane P.},
+    Title = {Controlling open quantum systems: tools, achievements, and limitations},
+    Journal = {J. Phys.: Condens. Matter},
+    Year = {2016},
+    Doi = {10.1088/0953-8984/28/21/213001},
+    Pages = {213001},
+    Volume = {28},
+}


### PR DESCRIPTION
`CitationBibliography` reads a single `bibfile`.

This is by design. Deviating from this opens a whole can of worms of edge cases and potential type instabilities. Still, for users who _really_ want this, this PR refactors some internals to provide a "dirty hack": Several files can now be combined by reading them with `Bibliography.import_bibtex`, merging the resulting dicts, and passing the result to a new `_entries` keyword argument:

```julia
bibfiles = ["refs_reviews.bib", "refs_books.bib"]
entries = merge(Bibliography.import_bibtex.(bibfiles)...)
bib = CitationBibliography(join(bibfiles, ", "); _entries=entries)
```

This is the resolution for #72, as far as we're willing to go. The `_entries` argument is deliberately undocumented, and combining bib files stays unsupported: the argument hands the caller the internal `entries` field of the plugin (which itself is not part of the stable API), and the merging is entirely the caller's business. What the package gains is the seam that makes the workaround possible, and a worked example that says how it is meant to be used.

## Implementation

* `CitationBibliography` no longer calls `Bibliography.import_bibtex` in its body. The call moves to the default value of the new `_entries` keyword argument, and further processing reads from there. Passing `_entries` therefore skips the reading of `bibfile` entirely.

* The existence check for `bibfile` moves along with it, into the new `_read_bibfile`. It used to run unconditionally, which would have rejected any `bibfile` that is not a path. With `_entries` given, `bibfile` is now only a label: nothing else in the package reads it, beyond naming the source of the entries in the errors for citation keys that are not found. It can then name all the files that went into the merged entries, which is what those errors should say.

The empty-`bibfile` warning stays in the constructor, since it applies to `CitationBibliography()` however the entries were obtained. Its `else` branch collapses into an `elseif`, so `No entries loaded from …` now also covers an empty `_entries` passed under a non-empty label.

## Testing

The new `test/test_multiple_bibfiles.jl` builds a documentation from two `.bib` files merged this way, and is commented throughout so that it can serve as a how-to in response to #72. It covers the order of the merged entries, the free-form `bibfile` label, citations of entries from both files, the fact that the citation numbers follow the order of the citations rather than the order of the entries, and a keyless `@bibliography` block listing all four entries. It also pins down that `bibfile` must still exist when `_entries` is omitted, which is the part of the old behavior that the move of the check has to preserve.

While multiple bib files remain unsupported, the existence of this test is an informal commitment to support this "hack" in non-breaking releases.

Closes #72.
